### PR TITLE
Ensure getLogs returns complete log list

### DIFF
--- a/lib/utils/logger/logger.dart
+++ b/lib/utils/logger/logger.dart
@@ -235,6 +235,8 @@ class BaseLogger extends GetxService {
       }
     }
 
+    if (currentLog.isNotEmpty) logs.add(currentLog);
+
     // Take the last [maxLines] logs.
     // We only want the logs starting from the end. But we want to keep the order of the logs.
     logs = logs.reversed.take(maxLines).toList().reversed.toList();

--- a/test/utils/logger_test.dart
+++ b/test/utils/logger_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:path/path.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/utils/logger/logger.dart';
+import 'package:bluebubbles/services/backend/filesystem/filesystem_service.dart';
+import 'package:get/get.dart';
+
+void main() {
+  setUp(() {
+    Get.reset();
+    Get.put(FilesystemService());
+  });
+
+  test('getLogs includes last log entry', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    fs.appDocDir = tempDir;
+    final logsDir = Directory(join(tempDir.path, 'logs'))..createSync(recursive: true);
+    final logFile = File(join(logsDir.path, 'bluebubbles-latest.log'));
+    logFile.writeAsStringSync(
+      '2024-01-01 First log\n'
+      'Continuation\n'
+      '2024-01-02 Second log',
+    );
+
+    final logger = BaseLogger();
+    final logs = await logger.getLogs();
+    expect(logs.length, 2);
+    expect(logs.last.contains('Second log'), isTrue);
+
+    tempDir.deleteSync(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- prevent `getLogs` from dropping the final log entry
- cover logger with unit test for final entry

## Testing
- `flutter test test/utils/logger_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad49a69c48833181e38a290f897938