### PR TITLE
fix: prevent RangeError when processing GIF delays

### DIFF
--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -21,7 +21,11 @@ Future<PlatformFile?> loadPathAsFile(String path) async {
 /// https://giflib.sourceforge.net/whatsinagif/animation_and_transparency.html
 Future<Uint8List> fixSpeedyGifs(Uint8List image) async {
   return await compute((image) {
-    for (int i = 0; i < image.length - 2; i++) {
+    // Ensure we always have enough bytes remaining to safely access
+    // [i + 4] and [i + 5]. The previous boundary check of
+    // `image.length - 2` could result in a RangeError when the pattern
+    // appeared near the end of the byte array.
+    for (int i = 0; i < image.length - 5; i++) {
       final slice = image.sublist(i, i + 3);
       if (const ListEquality().equals(slice, [0x21, 0xF9, 0x04])) {
         final delay1 = image[i + 4];


### PR DESCRIPTION
## Summary
- avoid out-of-range access when adjusting GIF frame delays

## Testing
- `dart format lib/utils/file_utils.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad49b2dc7483318f1d8dc8271e270d