### PR TITLE
refactor(logger): add provider-based registration

### DIFF
--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -30,6 +30,7 @@ class StartupTasks {
     await fs.init();
 
     // Initialize the logger so we can start logging things immediately
+    initLogger();
     await Logger.init();
     Logger.debug("Initializing startup services...");
 
@@ -68,6 +69,7 @@ class StartupTasks {
   static Future<void> initIsolateServices() async {
     debugPrint("Initializing isolate services...");
     await fs.init(headless: true);
+    initLogger();
     await Logger.init();
     Logger.debug("Initializing isolate services...");
     await ss.init(headless: true);
@@ -79,6 +81,7 @@ class StartupTasks {
   static Future<void> initIncrementalSyncServices() async {
     debugPrint("Initializing incremental sync services...");
     await fs.init();
+    initLogger();
     await Logger.init();
     Logger.debug("Initializing incremental sync services...");
     await ss.init();

--- a/lib/utils/logger/logger.dart
+++ b/lib/utils/logger/logger.dart
@@ -14,10 +14,25 @@ import 'package:logger/logger.dart' as LoggerFactory;
 
 import 'outputs/debug_console_output.dart';
 
+BaseLogger initLogger({
+  LoggerFactory.LogFilter? filter,
+  LoggerFactory.LogOutput? output,
+  LoggerFactory.Level? level,
+  bool? showColors,
+  Map<Level, bool>? excludeBoxes,
+}) {
+  if (Get.isRegistered<BaseLogger>()) return Get.find<BaseLogger>();
+  return Get.put(BaseLogger(
+    filter: filter,
+    output: output,
+    level: level,
+    showColors: showColors,
+    excludeBoxes: excludeBoxes,
+  ));
+}
+
 // ignore: non_constant_identifier_names
-BaseLogger Logger = Get.isRegistered<BaseLogger>()
-    ? Get.find<BaseLogger>()
-    : Get.put(BaseLogger());
+BaseLogger get Logger => Get.find<BaseLogger>();
 
 enum LogLevel { INFO, WARN, ERROR, DEBUG, TRACE, FATAL }
 
@@ -31,6 +46,18 @@ const Map<Level, bool> defaultExcludeBoxes = {
 };
 
 class BaseLogger extends GetxService {
+  BaseLogger({
+    LoggerFactory.LogFilter? filter,
+    LoggerFactory.LogOutput? output,
+    LoggerFactory.Level? level,
+    bool? showColors,
+    Map<Level, bool>? excludeBoxes,
+  })  : _currentFilter = filter,
+        _currentOutput = output,
+        _currentLevel = level,
+        _showColors = showColors,
+        _excludeBoxes = excludeBoxes;
+
   LoggerFactory.Logger _logger = LoggerFactory.Logger();
 
   final StreamController<String> logStream =


### PR DESCRIPTION
## Summary
- allow BaseLogger to be constructed with optional configuration and outputs
- expose an `initLogger` provider and remove global logger variable
- register logger through `initLogger` in startup services

## Testing
- `dart format lib/utils/logger/logger.dart lib/helpers/backend/startup_tasks.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4bb5f1a883319042c83e1f5bfbed