### PR TITLE
feat: make max attachment downloads configurable

### DIFF
--- a/lib/app/layouts/settings/pages/message_view/attachment_panel.dart
+++ b/lib/app/layouts/settings/pages/message_view/attachment_panel.dart
@@ -50,6 +50,20 @@ class _AttachmentPanelState extends OptimizedState<AttachmentPanel> {
                           title: "Only Auto-download Attachments on WiFi",
                           backgroundColor: tileColor,
                         )),
+                    const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                    const SettingsTile(
+                      title: "Concurrent Attachment Downloads",
+                      subtitle: "Adjust how many attachments are downloaded simultaneously",
+                    ),
+                    Obx(() => SettingsSlider(
+                          startingVal: ss.settings.maxAttachmentDownloads.value.toDouble(),
+                          min: 1,
+                          max: 5,
+                          divisions: 4,
+                          formatValue: (val) => val.toInt().toString(),
+                          update: (val) => ss.settings.maxAttachmentDownloads.value = val.toInt(),
+                          onChangeEnd: (val) => saveSettings(),
+                        )),
                     if (!kIsWeb && !kIsDesktop)
                       const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
                     if (!kIsWeb && !kIsDesktop)

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -22,6 +22,7 @@ class Settings {
   final RxBool reachedConversationList = false.obs;
   final RxBool autoDownload = true.obs;
   final RxBool onlyWifiDownload = false.obs;
+  final RxInt maxAttachmentDownloads = 2.obs;
   final RxBool autoSave = false.obs;
   final RxString autoSavePicsLocation = "Pictures".obs;
   final RxString autoSaveDocsLocation = "/storage/emulated/0/Download/".obs;
@@ -257,6 +258,7 @@ class Settings {
     Map<String, dynamic> map = {
       'autoDownload': autoDownload.value,
       'onlyWifiDownload': onlyWifiDownload.value,
+      'maxAttachmentDownloads': maxAttachmentDownloads.value,
       'autoSave': autoSave.value,
       'autoSavePicsLocation': autoSavePicsLocation.value,
       'autoSaveDocsLocation': autoSaveDocsLocation.value,
@@ -389,6 +391,7 @@ class Settings {
   static void updateFromMap(Map<String, dynamic> map) {
     ss.settings.autoDownload.value = map['autoDownload'] ?? true;
     ss.settings.onlyWifiDownload.value = map['onlyWifiDownload'] ?? false;
+    ss.settings.maxAttachmentDownloads.value = map['maxAttachmentDownloads'] ?? 2;
     ss.settings.autoSave.value = map['autoSave'] ?? false;
     ss.settings.autoSavePicsLocation.value = map['autoSavePicsLocation'] ?? "Pictures";
     ss.settings.autoSaveDocsLocation.value = map['autoSaveDocsLocation'] ?? "/storage/emulated/0/Download/";
@@ -525,6 +528,7 @@ class Settings {
     s.autoSavePicsLocation.value = map['autoSavePicsLocation'] ?? "Pictures";
     s.autoSaveDocsLocation.value = map['autoSaveDocsLocation'] ?? "/storage/emulated/0/Download/";
     s.onlyWifiDownload.value = map['onlyWifiDownload'] ?? false;
+    s.maxAttachmentDownloads.value = map['maxAttachmentDownloads'] ?? 2;
     s.autoOpenKeyboard.value = map['autoOpenKeyboard'] ?? true;
     s.hideTextPreviews.value = map['hideTextPreviews'] ?? false;
     s.showIncrementalSync.value = map['showIncrementalSync'] ?? false;

--- a/lib/services/network/downloads_service.dart
+++ b/lib/services/network/downloads_service.dart
@@ -15,9 +15,15 @@ AttachmentDownloadService attachmentDownloader = Get.isRegistered<AttachmentDown
     ? Get.find<AttachmentDownloadService>() : Get.put(AttachmentDownloadService());
 
 class AttachmentDownloadService extends GetxService {
-  int maxDownloads = 2;
+  int get maxDownloads => ss.settings.maxAttachmentDownloads.value;
   final RxList<String> downloaders = <String>[].obs;
   final Map<String, List<AttachmentDownloadController>> _downloaders = {};
+
+  @override
+  void onInit() {
+    super.onInit();
+    ever<int>(ss.settings.maxAttachmentDownloads, (_) => _fetchNext());
+  }
 
   AttachmentDownloadController? getController(String? guid) {
     return _downloaders.values.flattened.firstWhereOrNull((element) => element.attachment.guid == guid);


### PR DESCRIPTION
## Summary
- make download concurrency configurable via maxAttachmentDownloads setting
- expose setting in attachments panel for user adjustment
- respect setting in AttachmentDownloadService and trigger queue refill when changed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f9d4c748331a9f2ad22af58a181