### PR TITLE
feat(queue): add concurrent processing with ordering

### DIFF
--- a/lib/database/global/queue_items.dart
+++ b/lib/database/global/queue_items.dart
@@ -9,6 +9,11 @@ abstract class QueueItem {
   Completer<void>? completer;
 
   QueueItem({required this.type, this.completer});
+
+  /// Identifier used by [Queue] to group items that must remain ordered. Items
+  /// sharing the same key will not be processed in parallel. Defaults to a
+  /// single global queue.
+  String get queueKey => 'global';
 }
 
 class IncomingItem extends QueueItem {
@@ -51,4 +56,7 @@ class OutgoingItem extends QueueItem {
     this.reaction,
     this.customArgs,
   });
+
+  @override
+  String get queueKey => chat.guid;
 }

--- a/lib/services/backend/queue/queue_impl.dart
+++ b/lib/services/backend/queue/queue_impl.dart
@@ -10,6 +10,21 @@ abstract class Queue extends GetxService {
   bool isProcessing = false;
   List<QueueItem> items = [];
 
+  /// Tracks chats that currently have an active send. This ensures ordering
+  /// is preserved per chat even when multiple items are processed in
+  /// parallel.
+  /// Active queue keys currently being processed. Keys allow higher level
+  /// implementations to define ordering groups (for example per chat or per
+  /// attachment batch).
+  final Set<String> _activeKeys = <String>{};
+
+  /// Number of items currently being processed.
+  int _processing = 0;
+
+  /// Maximum number of concurrent [handleQueueItem] calls. This can be tuned
+  /// based on performance characteristics of the target platform.
+  int maxConcurrent = 3;
+
   Future<void> queue(QueueItem item) async {
     final returned = await prepItem(item);
     // we may get a link split into 2 messages
@@ -31,18 +46,38 @@ abstract class Queue extends GetxService {
   Future<dynamic> prepItem(QueueItem _);
 
   Future<void> processNextItem() async {
-    if (items.isEmpty) {
+    // If there are no more queued items and nothing is being processed, stop
+    // the processing loop.
+    if (items.isEmpty && _processing == 0) {
       isProcessing = false;
       return;
     }
 
     isProcessing = true;
-    QueueItem queued = items.removeAt(0);
 
+    // Fill available concurrency slots with queued items that are not blocked
+    // by an active chat.
+    while (_processing < maxConcurrent) {
+      // Find the first item whose chat is not currently processing.
+      final index = items.indexWhere((item) => !_activeKeys.contains(item.queueKey));
+
+      if (index == -1) break;
+
+      final queued = items.removeAt(index);
+      _activeKeys.add(queued.queueKey);
+
+      _processing++;
+      _processItem(queued);
+    }
+  }
+
+  Future<void> _processItem(QueueItem queued) async {
     try {
       await handleQueueItem(queued).catchError((err) async {
         if (queued is OutgoingItem && ss.settings.cancelQueuedMessages.value) {
-          final toCancel = List<OutgoingItem>.from(items.whereType<OutgoingItem>().where((e) => e.chat.guid == queued.chat.guid));
+          final toCancel = List<OutgoingItem>.from(
+            items.whereType<OutgoingItem>().where((e) => e.chat.guid == queued.chat.guid),
+          );
           for (OutgoingItem i in toCancel) {
             items.remove(i);
             final m = i.message;
@@ -57,9 +92,12 @@ abstract class Queue extends GetxService {
     } catch (ex, stacktrace) {
       Logger.error("Failed to handle queued item!", error: ex, trace: stacktrace);
       queued.completer?.completeError(ex);
+    } finally {
+      _activeKeys.remove(queued.queueKey);
+      _processing--;
+      // Trigger processing of additional items if available.
+      await processNextItem();
     }
-
-    await processNextItem();
   }
 
   Future<void> handleQueueItem(QueueItem _);

--- a/test/queue_concurrency_test.dart
+++ b/test/queue_concurrency_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:bluebubbles/services/backend/queue/queue_impl.dart';
+import 'package:bluebubbles/database/global/queue_items.dart';
+
+class SimpleItem extends QueueItem {
+  final String key;
+  SimpleItem(this.key) : super(type: QueueType.sendMessage);
+
+  @override
+  String get queueKey => key;
+}
+
+class SimpleQueue extends Queue {
+  final List<String> processed = [];
+
+  @override
+  Future<dynamic> prepItem(QueueItem _) async => _;
+
+  @override
+  Future<void> handleQueueItem(QueueItem item) async {
+    if ((item as SimpleItem).key == 'fail') {
+      throw Exception('boom');
+    }
+    processed.add(item.key);
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+}
+
+void main() {
+  test('items for same key are processed sequentially', () async {
+    final q = SimpleQueue();
+    final completers = List.generate(3, (_) => Completer<void>());
+
+    q.queue(SimpleItem('a')..completer = completers[0]);
+    q.queue(SimpleItem('a')..completer = completers[1]);
+    q.queue(SimpleItem('a')..completer = completers[2]);
+
+    await Future.wait(completers.map((c) => c.future));
+
+    expect(q.processed, ['a', 'a', 'a']);
+  });
+
+  test('different keys run concurrently', () async {
+    final q = SimpleQueue()..maxConcurrent = 2;
+
+    final c1 = Completer<void>();
+    final c2 = Completer<void>();
+
+    q.queue(SimpleItem('a')..completer = c1);
+    q.queue(SimpleItem('b')..completer = c2);
+
+    final sw = Stopwatch()..start();
+    await Future.wait([c1.future, c2.future]);
+    sw.stop();
+
+    // Since both items run in parallel the elapsed time should be roughly the
+    // duration of a single item rather than the sum.
+    expect(sw.elapsedMilliseconds < 180, isTrue);
+  });
+
+  test('failure in one key does not block others', () async {
+    final q = SimpleQueue()..maxConcurrent = 2;
+
+    final good = Completer<void>();
+    final bad = Completer<void>();
+
+    q.queue(SimpleItem('fail')..completer = bad);
+    q.queue(SimpleItem('b')..completer = good);
+
+    await good.future;
+    expect(q.processed, contains('b'));
+  });
+}
+


### PR DESCRIPTION
## Summary
- add generic queue key to QueueItem and expose chat guid for outgoing items
- run multiple queue items in parallel while preserving ordering per key
- add concurrency tests to validate sequential per-chat order and error isolation

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f9e4b348331ade0e9323479205a