### PR TITLE
Handle missing error message in network error handler

### DIFF
--- a/lib/helpers/network/network_error_handler.dart
+++ b/lib/helpers/network/network_error_handler.dart
@@ -4,7 +4,15 @@ import 'package:dio/dio.dart';
 
 Message handleSendError(dynamic error, Message m) {
   if (error is Response) {
-    m.guid = m.guid!.replaceAll("temp", "error-${error.data['error']['message'] ?? error.data.toString()}");
+    dynamic data = error.data;
+    String errorMessage;
+    if (data is Map && data['error'] is Map && (data['error'] as Map).containsKey('message')) {
+      errorMessage = (data['error'] as Map)['message'].toString();
+    } else {
+      errorMessage = data.toString();
+    }
+
+    m.guid = m.guid!.replaceAll("temp", "error-$errorMessage");
     m.error = error.statusCode ?? MessageError.BAD_REQUEST.code;
   } else if (error is DioException) {
     String _error;


### PR DESCRIPTION
## Summary
- Guard against unexpected response formats in `handleSendError`
- Fallback to generic stringified data when nested error message is absent

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ffbb5b4833194b5c5f626cd7c51