### PR TITLE
docs: clarify chat creator subtitle

### DIFF
--- a/lib/database/html/chat.dart
+++ b/lib/database/html/chat.dart
@@ -203,7 +203,7 @@ class Chat {
     return title!;
   }
 
-  /// Get a chat's title
+  /// Generate a subtitle for a chat creator
   String getChatCreatorSubtitle() {
     // generate names for group chats or DMs
     List<String> titles = participants.map((e) => e.displayName.trim().split(isGroup && e.contact != null ? " " : String.fromCharCode(65532)).first).toList();


### PR DESCRIPTION
## Summary
- clarify that `getChatCreatorSubtitle` generates a subtitle for the chat creator

## Testing
- `dart analyze lib/database/html/chat.dart` *(fails: command not found)*
- `flutter analyze lib/database/html/chat.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ffc8c14833185fd4c4478c8d428