### PR TITLE
Add custom GetX service and demo widget

### DIFF
--- a/lib/app/components/custom_service_widget.dart
+++ b/lib/app/components/custom_service_widget.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../services/custom_service.dart';
+
+class CustomServiceWidget extends StatelessWidget {
+  CustomServiceWidget({super.key});
+
+  final CustomService service = customService;
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Count: ${service.count.value}'),
+            ElevatedButton(
+              onPressed: service.increment,
+              child: const Text('Increment'),
+            ),
+          ],
+        ));
+  }
+}

--- a/lib/services/custom_service.dart
+++ b/lib/services/custom_service.dart
@@ -1,0 +1,23 @@
+import 'package:get/get.dart';
+
+class CustomService extends GetxService {
+  final count = 0.obs;
+
+  void increment() => count.value++;
+
+  @override
+  void onInit() {
+    super.onInit();
+    print('CustomService initialized');
+  }
+
+  @override
+  void onClose() {
+    print('CustomService disposed');
+    super.onClose();
+  }
+}
+
+CustomService customService = Get.isRegistered<CustomService>()
+    ? Get.find<CustomService>()
+    : Get.put(CustomService());

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -35,3 +35,4 @@ export 'ui/theme/themes_service.dart';
 export 'ui/attachments_service.dart';
 export 'ui/contact_service.dart';
 export 'ui/unifiedpush.dart';
+export 'custom_service.dart';


### PR DESCRIPTION
## Summary
- add a small `CustomService` with lifecycle logs and counter
- export the service through the services barrel file
- create `CustomServiceWidget` demonstrating GetX injection and reactive state

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad50029a088331a6cf1ffc35ddcc8a