### PR TITLE
Fix typos in setup and network error messages

### DIFF
--- a/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
+++ b/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
@@ -199,7 +199,7 @@ class _ManualEntryDialogState extends OptimizedState<ManualEntryDialog> {
       );
     } else if (error != null) {
       return FailedToScanDialog(
-        title: "An error occured while trying to retreive data!",
+        title: "An error occurred while trying to retrieve data!",
         exception: error,
       );
     } else {

--- a/lib/app/layouts/setup/pages/sync/sync_progress.dart
+++ b/lib/app/layouts/setup/pages/sync/sync_progress.dart
@@ -41,7 +41,7 @@ class _SyncProgressState extends OptimizedState<SyncProgress> {
       if (event == SyncStatus.COMPLETED_ERROR) {
         await showDialog(
           context: context,
-          builder: (context) => FailedToScanDialog(exception: err, title: "An error occured during setup!"),
+          builder: (context) => FailedToScanDialog(exception: err, title: "An error occurred during setup!"),
         );
 
         controller.pageController.animateToPage(

--- a/lib/helpers/network/network_error_handler.dart
+++ b/lib/helpers/network/network_error_handler.dart
@@ -9,11 +9,11 @@ Message handleSendError(dynamic error, Message m) {
   } else if (error is DioException) {
     String _error;
     if (error.type == DioExceptionType.connectionTimeout) {
-      _error = "Connect timeout occured! Check your connection.";
+      _error = "Connect timeout occurred! Check your connection.";
     } else if (error.type == DioExceptionType.sendTimeout) {
-      _error = "Send timeout occured!";
+      _error = "Send timeout occurred!";
     } else if (error.type == DioExceptionType.receiveTimeout) {
-      _error = "Receive data timeout occured! Check server logs for more info.";
+      _error = "Receive data timeout occurred! Check server logs for more info.";
     } else {
       _error = error.error.toString();
     }


### PR DESCRIPTION
## Summary
- correct "occured" typos in network timeout handling
- fix spelling of setup error dialog titles and messages

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad500b5d288331b0028ac1a0f624b7