### PR TITLE
Reset connecting flag when manual entry validation fails

### DIFF
--- a/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
+++ b/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
@@ -57,14 +57,16 @@ class _ManualEntryDialogState extends OptimizedState<ManualEntryDialog> {
     // If the URL is invalid, or the password is invalid, show an error
     if (!isValid || password.isEmpty) {
       error = "Please enter a valid URL and password!";
-      setState(() {});
+      connecting = false;
+      if (mounted) setState(() {});
       return;
     }
 
     String? addr = sanitizeServerAddress(address: url);
     if (addr == null) {
       error = "Server address is invalid!";
-      setState(() {});
+      connecting = false;
+      if (mounted) setState(() {});
       return;
     }
 


### PR DESCRIPTION
## Summary
- Reset connecting flag and refresh dialog when manual entry validation fails

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad500c3b308331b27d2c6b69e8911b