### PR TITLE
fix: ensure server address getter uses value

### DIFF
--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -60,9 +60,9 @@ class HttpService extends GetxService {
   }
 
   Map<String, String> get headers {
-    if (ss.settings.serverAddress.contains('ngrok')) {
+    if (ss.settings.serverAddress.value.contains('ngrok')) {
       ss.settings.customHeaders.addAll({'ngrok-skip-browser-warning': 'true'});
-    } else if (ss.settings.serverAddress.contains('zrok')) {
+    } else if (ss.settings.serverAddress.value.contains('zrok')) {
       ss.settings.customHeaders.addAll({'skip_zrok_interstitial': 'true'});
     }
 


### PR DESCRIPTION
## Summary
- fix headers serverAddress contains checks to use `.value`

## Testing
- `flutter analyze lib/services/network/http_service.dart` *(fails: command not found)*
- `dart analyze lib/services/network/http_service.dart` *(fails: command not found)*
- `dart /tmp/test_headers.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad501b6c308331a205ab949cc69713