### PR TITLE
docs: clarify sanitizeServerAddress scheme comment

### DIFF
--- a/lib/helpers/network/network_helpers.dart
+++ b/lib/helpers/network/network_helpers.dart
@@ -5,7 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:universal_io/io.dart';
 
 /// Take the passed [address] or serverAddress from Settings
-/// and sanitize it, making sure it includes an http schema
+/// and sanitize it, ensuring it includes an HTTP or HTTPS scheme.
+/// Uses HTTPS for ngrok.io, trycloudflare.com, and zrok.io addresses; otherwise HTTP.
 String? sanitizeServerAddress({String? address}) {
   String serverAddress = address ?? http.origin;
 


### PR DESCRIPTION
## Summary
- clarify sanitizeServerAddress comment to use correct term *scheme*
- document when https vs http scheme is added

## Testing
- `dart format lib/helpers/network/network_helpers.dart` *(command not found)*
- `flutter format lib/helpers/network/network_helpers.dart` *(command not found)*
- `flutter test` *(command not found)*
- `apt-get update` *(403 Forbidden, repository not signed)*
- `apt-get install -y dart` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ad501c021c833180b023cd1f2e0b0c