### PR TITLE
Add tests for sanitizeServerAddress prefixes

### DIFF
--- a/test/network_helpers_test.dart
+++ b/test/network_helpers_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/helpers/network/network_helpers.dart';
+
+void main() {
+  group('sanitizeServerAddress', () {
+    test('adds http prefix for plain host', () {
+      final result = sanitizeServerAddress(address: 'example.com');
+      expect(result, 'http://example.com');
+    });
+
+    test('adds https prefix for ngrok host', () {
+      final result = sanitizeServerAddress(address: 'my-ngrok.ngrok.io');
+      expect(result, 'https://my-ngrok.ngrok.io');
+    });
+
+    test('adds https prefix for zrok host', () {
+      final result = sanitizeServerAddress(address: 'my-zrok.zrok.io');
+      expect(result, 'https://my-zrok.zrok.io');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- test: ensure sanitizeServerAddress prepends http for plain hosts
- test: ensure https is used for ngrok and zrok hosts

## Testing
- `flutter test test/network_helpers_test.dart` *(fails: command not found)*
- `dart test test/network_helpers_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad501caeb08331938c6752acda25ea