### PR TITLE
feat: add chaos and stress test settings

### DIFF
--- a/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
@@ -140,6 +140,39 @@ class _TroubleshootPanelState extends OptimizedState<TroubleshootPanel> {
                       ),
                     ],
                   ),
+                SettingsHeader(
+                    iosSubtitle: iosSubtitle,
+                    materialSubtitle: materialSubtitle,
+                    text: "Testing"),
+                SettingsSection(backgroundColor: tileColor, children: [
+                  Obx(() => SettingsSwitch(
+                        initialVal: ss.settings.chaosMode.value,
+                        title: "Chaos Mode",
+                        subtitle:
+                            "Introduce random failures to test error handling",
+                        backgroundColor: tileColor,
+                        onChanged: (bool val) async {
+                          await saveNewServerUrl(ss.settings.serverAddress.value,
+                              chaosMode: val,
+                              restartSocket: true,
+                              tryRestartForegroundService: false);
+                        },
+                      )),
+                  const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                  Obx(() => SettingsSwitch(
+                        initialVal: ss.settings.stressMode.value,
+                        title: "Stress Mode",
+                        subtitle:
+                            "Enable heavy load scenarios for performance testing",
+                        backgroundColor: tileColor,
+                        onChanged: (bool val) async {
+                          await saveNewServerUrl(ss.settings.serverAddress.value,
+                              stressMode: val,
+                              restartSocket: true,
+                              tryRestartForegroundService: false);
+                        },
+                      )),
+                ]),
                 if (isWebOrDesktop)
                   SettingsHeader(
                       iosSubtitle: iosSubtitle,

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -153,6 +153,8 @@ class Settings {
 
   // Troubleshooting settings
   final Rx<Level> logLevel = Level.info.obs;
+  final RxBool chaosMode = false.obs;
+  final RxBool stressMode = false.obs;
 
   // Notification actions
   final RxList<int> selectedActionIndices = Platform.isWindows ? [0, 1, 2, 3, 4].obs : [0, 1, 2].obs;
@@ -363,6 +365,8 @@ class Settings {
       'windowEffectCustomOpacityDark': windowEffectCustomOpacityDark.value,
       'useWindowsAccent': useWindowsAccent.value,
       'logLevel': logLevel.value.index,
+      'chaosMode': chaosMode.value,
+      'stressMode': stressMode.value,
       'hideNamesForReactions': hideNamesForReactions.value,
       'replaceEmoticonsWithEmoji': replaceEmoticonsWithEmoji.value,
       'lastReviewRequestTimestamp': lastReviewRequestTimestamp.value,
@@ -506,6 +510,8 @@ class Settings {
     ss.settings.useWindowsAccent.value = map['useWindowsAccent'] ?? false;
     ss.settings.firstFcmRegisterDate.value = map['firstFcmRegisterDate'] ?? 0;
     ss.settings.logLevel.value = map['logLevel'] != null ? Level.values[map['logLevel']] : Level.info;
+    ss.settings.chaosMode.value = map['chaosMode'] ?? false;
+    ss.settings.stressMode.value = map['stressMode'] ?? false;
     ss.settings.hideNamesForReactions.value = map['hideNamesForReactions'] ?? false;
     ss.settings.replaceEmoticonsWithEmoji.value = map['replaceEmoticonsWithEmoji'] ?? false;
     ss.settings.save();
@@ -645,6 +651,8 @@ class Settings {
     s.useWindowsAccent.value = map['useWindowsAccent'] ?? false;
     s.firstFcmRegisterDate.value = map['firstFcmRegisterDate'] ?? 0;
     s.logLevel.value = map['logLevel'] != null ? Level.values[map['logLevel']] : Level.info;
+    s.chaosMode.value = map['chaosMode'] ?? false;
+    s.stressMode.value = map['stressMode'] ?? false;
     s.hideNamesForReactions.value = map['hideNamesForReactions'] ?? false;
     s.replaceEmoticonsWithEmoji.value = map['replaceEmoticonsWithEmoji'] ?? false;
     s.lastReviewRequestTimestamp.value = map['lastReviewRequestTimestamp'] ?? 0;

--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -56,7 +56,11 @@ class SocketService extends GetxService {
 
   void startSocket() {
     OptionBuilder options = OptionBuilder()
-        .setQuery({"guid": password})
+        .setQuery({
+          "guid": password,
+          "chaosMode": ss.settings.chaosMode.value.toString(),
+          "stressMode": ss.settings.stressMode.value.toString(),
+        })
         .setTransports(['websocket', 'polling'])
         .setExtraHeaders(http.headers)
         // Disable so that we can create the listeners first


### PR DESCRIPTION
## Summary
- add chaosMode & stressMode fields to settings and saveNewServerUrl
- expose chaos and stress mode toggles in Developer Tools panel
- send chaos and stress flags when initializing socket connection

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad51804ff48331a21fb9e9fa49a3b1