### PR TITLE
feat: simulate slow server responses

### DIFF
--- a/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
@@ -71,6 +71,26 @@ class _TroubleshootPanelState extends OptimizedState<TroubleshootPanel> {
           SliverList(
             delegate: SliverChildListDelegate(
               <Widget>[
+                SettingsSection(
+                  backgroundColor: tileColor,
+                  children: [
+                    Obx(() => SettingsSwitch(
+                          initialVal: ss.settings.simulateServerDelay.value,
+                          onChanged: (bool val) async {
+                            ss.settings.simulateServerDelay.value = val;
+                            await ss.settings.saveOne('simulateServerDelay');
+                          },
+                          title: "Simulate Slow Server",
+                          subtitle: "Adds a delay to network requests",
+                          backgroundColor: tileColor,
+                          leading: const SettingsLeadingIcon(
+                            iosIcon: CupertinoIcons.timer,
+                            materialIcon: Icons.timer,
+                            containerColor: Colors.orange,
+                          ),
+                        )),
+                  ],
+                ),
                 if (isWebOrDesktop)
                   SettingsSection(
                     backgroundColor: tileColor,

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -71,6 +71,7 @@ class Settings {
   final RxBool askWhereToSave = false.obs;
   final RxBool statusIndicatorsOnChats = false.obs;
   final RxInt apiTimeout = 30000.obs;
+  final RxBool simulateServerDelay = false.obs;
   final RxBool allowUpsideDownRotation = false.obs;
   final RxBool cancelQueuedMessages = false.obs;
   final RxBool repliesToPrevious = false.obs;
@@ -312,6 +313,7 @@ class Settings {
       'askWhereToSave': askWhereToSave.value,
       'indicatorsOnPinnedChats': statusIndicatorsOnChats.value,
       'apiTimeout': apiTimeout.value,
+      'simulateServerDelay': simulateServerDelay.value,
       'allowUpsideDownRotation': allowUpsideDownRotation.value,
       'cancelQueuedMessages': cancelQueuedMessages.value,
       'repliesToPrevious': repliesToPrevious.value,
@@ -439,6 +441,7 @@ class Settings {
     ss.settings.askWhereToSave.value = map['askWhereToSave'] ?? false;
     ss.settings.statusIndicatorsOnChats.value = map['indicatorsOnPinnedChats'] ?? false;
     ss.settings.apiTimeout.value = map['apiTimeout'] ?? 15000;
+    ss.settings.simulateServerDelay.value = map['simulateServerDelay'] ?? false;
     ss.settings.allowUpsideDownRotation.value = map['allowUpsideDownRotation'] ?? false;
     ss.settings.cancelQueuedMessages.value = map['cancelQueuedMessages'] ?? false;
     ss.settings.repliesToPrevious.value = map['repliesToPrevious'] ?? false;
@@ -577,6 +580,7 @@ class Settings {
     s.askWhereToSave.value = map['askWhereToSave'] ?? false;
     s.statusIndicatorsOnChats.value = map['indicatorsOnPinnedChats'] ?? false;
     s.apiTimeout.value = map['apiTimeout'] ?? 15000;
+    s.simulateServerDelay.value = map['simulateServerDelay'] ?? false;
     s.allowUpsideDownRotation.value = map['allowUpsideDownRotation'] ?? false;
     s.cancelQueuedMessages.value = map['cancelQueuedMessages'] ?? false;
     s.repliesToPrevious.value = map['repliesToPrevious'] ?? false;

--- a/lib/helpers/backend/settings_helpers.dart
+++ b/lib/helpers/backend/settings_helpers.dart
@@ -10,9 +10,13 @@ Future<bool> saveNewServerUrl(
     bool tryRestartForegroundService = true,
     bool restartSocket = true,
     bool force = false,
-    List<String> saveAdditionalSettings = const []
+    List<String> saveAdditionalSettings = const [],
+    Duration? delay,
   }
 ) async {
+  if (ss.settings.simulateServerDelay.value || delay != null) {
+    await Future.delayed(delay ?? const Duration(seconds: 2));
+  }
   String sanitized = sanitizeServerAddress(address: newServerUrl)!;
   if (force || sanitized != ss.settings.serverAddress.value) {
     ss.settings.serverAddress.value = sanitized;
@@ -41,9 +45,13 @@ Future<bool> saveNewServerUrl(
 Future<void> clearServerUrl(
   {
     bool tryRestartForegroundService = true,
-    List<String> saveAdditionalSettings = const []
+    List<String> saveAdditionalSettings = const [],
+    Duration? delay,
   }
 ) async {
+  if (ss.settings.simulateServerDelay.value || delay != null) {
+    await Future.delayed(delay ?? const Duration(seconds: 2));
+  }
   ss.settings.serverAddress.value = "";
   await ss.settings.saveMany(["serverAddress", ...saveAdditionalSettings]);
 

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -30,8 +30,17 @@ class HttpService extends GetxService {
     return params;
   }
 
-  /// Global try-catch function
-  Future<Response> runApiGuarded(Future<Response> Function() func, {bool checkOrigin = true}) async {
+  /// Global try-catch function with optional artificial delay
+  Future<Response> runApiGuarded(
+    Future<Response> Function() func, {
+    bool checkOrigin = true,
+    Duration? delay,
+  }) async {
+    // Simulate slow server responses when enabled in settings or when a delay is provided
+    if (ss.settings.simulateServerDelay.value || delay != null) {
+      await Future.delayed(delay ?? const Duration(seconds: 2));
+    }
+
     if (http.origin.isEmpty && checkOrigin) {
       return Future.error("No server URL!");
     }


### PR DESCRIPTION
## Summary
- add developer setting to simulate slow server replies
- support optional artificial delay in backend network helpers
- allow HttpService to inject request delays

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5183321483319624c08b36e16c66