### PR TITLE
Add startup services stress test

### DIFF
--- a/test/startup_tasks_stress_test.dart
+++ b/test/startup_tasks_stress_test.dart
@@ -1,0 +1,32 @@
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/helpers/backend/startup_tasks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('StartupTasks.initStartupServices stress test', () {
+    test('sequential initialization', () async {
+      const iterations = 5;
+      final stopwatch = Stopwatch()..start();
+      final memUsage = <int>[];
+      for (var i = 0; i < iterations; i++) {
+        await StartupTasks.initStartupServices();
+        final rss = ProcessInfo.currentRss;
+        memUsage.add(rss);
+        Timeline.instantSync('init iteration', arguments: {'iteration': i, 'rss': rss});
+      }
+      stopwatch.stop();
+      // Output memory usage for manual inspection
+      print('Memory usage (RSS): $memUsage');
+      print('Total elapsed: ${stopwatch.elapsed}');
+    });
+
+    test('concurrent initialization', () async {
+      const runs = 3;
+      await Future.wait(List.generate(runs, (_) => StartupTasks.initStartupServices()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add stress test harness for StartupTasks.initStartupServices with sequential and concurrent runs
- log memory usage and timeline events for profiling

## Testing
- `dart format test/startup_tasks_stress_test.dart` (fails: command not found)
- `flutter test test/startup_tasks_stress_test.dart` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68ad5183eda083318023711841e6750b