### PR TITLE
Use Logger.error for DB failures

### DIFF
--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -195,13 +195,7 @@ class BulkSaveNewMessages extends AsyncTask<List<dynamic>, List<Message>> {
       }
 
       // 10. Save the updated associated messages
-      if (messagesToUpdate.isNotEmpty) {
-        try {
-          Database.messages.putMany(messagesToUpdate.values.toList());
-        } catch (ex) {
-          print('Failed to put associated messages into DB: ${ex.toString()}');
-        }
-      }
+      saveUpdatedAssociatedMessages(messagesToUpdate);
 
       // 11. Update the associated chat's last message
       messages.sort(Message.sort);
@@ -224,6 +218,17 @@ class BulkSaveNewMessages extends AsyncTask<List<dynamic>, List<Message>> {
 
       return messages;
     });
+  }
+}
+
+/// Saves [messagesToUpdate] to the database, logging any failures.
+void saveUpdatedAssociatedMessages(Map<String, Message> messagesToUpdate) {
+  if (messagesToUpdate.isNotEmpty) {
+    try {
+      Database.messages.putMany(messagesToUpdate.values.toList());
+    } catch (ex, stacktrace) {
+      Logger.error('Failed to put associated messages into DB!', error: ex, trace: stacktrace);
+    }
   }
 }
 

--- a/test/message_logging_test.dart
+++ b/test/message_logging_test.dart
@@ -1,0 +1,32 @@
+import 'package:bluebubbles/database/io/message.dart';
+import 'package:bluebubbles/utils/logger/logger.dart';
+import 'package:bluebubbles/utils/logger/outputs/log_stream_output.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('logs error when saving associated messages fails', () async {
+    // Direct logs to the in-memory stream
+    Logger.currentOutput = LogStreamOutput();
+
+    final logs = <String>[];
+    final sub = Logger.logStream.stream.listen(logs.add);
+
+    // Trigger a failure by leaving Database.messages uninitialized
+    final msg = Message(guid: 'test');
+    saveUpdatedAssociatedMessages({'test': msg});
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await sub.cancel();
+
+    expect(
+      logs.any(
+        (line) =>
+            line.contains('Failed to put associated messages into DB!'),
+      ),
+      isTrue,
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
- log database putMany failures with Logger.error
- add helper to save associated messages and expose for tests
- add test verifying logging on failure

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*
- ⚠️ `dart test` *(command not found: dart)*
- ⚠️ `apt-get update` *(403 Forbidden while attempting package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68ad55040a2083319561d0f77405435c