### PR TITLE
Refactor startup into modular helpers with tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,155 +54,156 @@ final systemTray = st.SystemTray();
 @pragma('vm:entry-point')
 //ignore: prefer_void_to_null
 Future<Null> main(List<String> arguments) async {
-  await initApp(false, arguments);
+  await initializeApp(false, arguments);
 }
 
 @pragma('vm:entry-point')
 // ignore: prefer_void_to_null
 Future<Null> bubble() async {
-  await initApp(true, []);
+  await initializeApp(true, []);
 }
 
 //ignore: prefer_void_to_null
-Future<Null> initApp(bool bubble, List<String> arguments) async {
+Future<Null> initializeApp(bool bubble, List<String> arguments) async {
   runZonedGuarded<Future<void>>(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
-
-      await StartupTasks.initStartupServices(isBubble: bubble);
-
-      /* ----- RANDOM STUFF INITIALIZATION ----- */
       HttpOverrides.global = BadCertOverride();
-      dynamic exception;
-      StackTrace? stacktrace;
-
       FlutterError.onError = (details) {
         Logger.error("Rendering Error: ${details.exceptionAsString()}", error: details.exception, trace: details.stack);
       };
 
-      try {
-        // Once all the services are initialized, we need to perform some
-        // startup tasks to ensure that the app has the information it needs.
-        StartupTasks.onStartup().then((_) {
-          Logger.info("Startup tasks completed");
-        }).catchError((e, s) {
-          Logger.error("Failed to complete startup tasks!", error: e, trace: s);
-        });
+      Exception? exception;
 
-        /* ----- DATE FORMATTING INITIALIZATION ----- */
-        await initializeDateFormatting();
-
-        /* ----- MEDIAKIT INITIALIZATION ----- */
-        MediaKit.ensureInitialized();
-
-        /* ----- SPLASH SCREEN INITIALIZATION ----- */
-        if (!ss.settings.finishedSetup.value && !kIsWeb && !kIsDesktop) {
-          runApp(MaterialApp(
-              home: SplashScreen(shouldNavigate: false),
-              theme: ThemeData(
-                colorScheme: ColorScheme.fromSwatch(
-                    backgroundColor:
-                        PlatformDispatcher.instance.platformBrightness == Brightness.dark ? Colors.black : Colors.white),
-              )));
-        }
-
-        /* ----- ANDROID SPECIFIC INITIALIZATION ----- */
-        if (!kIsWeb && !kIsDesktop) {
-          /* ----- TIME ZONE INITIALIZATION ----- */
-          tz.initializeTimeZones();
-          try {
-            tz.setLocalLocation(tz.getLocation(await FlutterTimezone.getLocalTimezone()));
-          } catch (_) {}
-
-          /* ----- MLKIT INITIALIZATION ----- */
-          if (!await EntityExtractorModelManager().isModelDownloaded(EntityExtractorLanguage.english.name)) {
-            EntityExtractorModelManager().downloadModel(EntityExtractorLanguage.english.name, isWifiRequired: false);
-          }
-        }
-
-        /* ----- DESKTOP SPECIFIC INITIALIZATION ----- */
-        if (kIsDesktop) {
-          /* ----- WINDOW INITIALIZATION ----- */
-          await windowManager.ensureInitialized();
-          await windowManager.setPreventClose(ss.settings.closeToTray.value);
-          await windowManager.setTitle('BlueBubbles');
-          await Window.initialize();
-          if (Platform.isWindows) {
-            await Window.hideWindowControls();
-          } else if (Platform.isLinux) {
-            await windowManager
-                .setTitleBarStyle(ss.settings.useCustomTitleBar.value ? TitleBarStyle.hidden : TitleBarStyle.normal);
-          }
-          windowManager.addListener(DesktopWindowListener.instance);
-          doWhenWindowReady(() async {
-            await windowManager.setMinimumSize(const Size(300, 300));
-            Display primary = await ScreenRetriever.instance.getPrimaryDisplay();
-
-            Size size = await windowManager.getSize();
-            double width = ss.prefs.getDouble("window-width") ?? size.width;
-            double height = ss.prefs.getDouble("window-height") ?? size.height;
-
-            width = width.clamp(300, max(300, primary.size.width));
-            height = height.clamp(300, max(300, primary.size.height));
-            await windowManager.setSize(Size(width, height));
-            await ss.prefs.setDouble("window-width", width);
-            await ss.prefs.setDouble("window-height", height);
-
-            await windowManager.setAlignment(Alignment.center);
-            Offset offset = await windowManager.getPosition();
-            double? posX = ss.prefs.getDouble("window-x") ?? offset.dx;
-            double? posY = ss.prefs.getDouble("window-y") ?? offset.dy;
-
-            posX = posX.clamp(0, max(0, primary.size.width - width));
-            posY = posY.clamp(0, max(0, primary.size.height - height));
-            await windowManager.setPosition(Offset(posX, posY), animate: true);
-            await ss.prefs.setDouble("window-x", posX);
-            await ss.prefs.setDouble("window-y", posY);
-
-            await windowManager.setTitle('BlueBubbles');
-            if (arguments.firstOrNull != "minimized") {
-              await windowManager.show();
-            }
-            if (!(ss.canAuthenticate && ss.settings.shouldSecure.value)) {
-              chats.init();
-              socket;
-            }
-          });
-
-          /* ----- GIPHY API KEY INITIALIZATION ----- */
-          await dotenv.load(fileName: '.env', isOptional: true);
-        }
-
-        /* ----- EMOJI FONT INITIALIZATION ----- */
-        fs.checkFont();
-      } catch (e, s) {
-        Logger.error("Failure during app initialization!", error: e, trace: s);
-        exception = e;
-        stacktrace = s;
+      exception ??= await _initServices(bubble, arguments);
+      if (!kIsWeb && !kIsDesktop && exception == null) {
+        exception ??= await _initTimezone();
+      }
+      if (kIsDesktop && exception == null) {
+        exception ??= await _initDesktopWindow(arguments);
       }
 
       if (exception == null) {
-        /* ----- THEME INITIALIZATION ----- */
-        ThemeData light = ThemeStruct.getLightTheme().data;
-        ThemeData dark = ThemeStruct.getDarkTheme().data;
-
-        final tuple = ts.getStructsFromData(light, dark);
-        light = tuple.item1;
-        dark = tuple.item2;
-
-        runApp(Main(
-          lightTheme: light,
-          darkTheme: dark,
-        ));
+        _initTheme();
       } else {
-        runApp(FailureToStart(e: exception, s: stacktrace));
-        throw Exception("$exception $stacktrace");
+        runApp(FailureToStart(e: exception));
+        throw exception;
       }
     },
     (dynamic error, StackTrace stackTrace) {
       Logger.error("Unhandled Exception", trace: stackTrace, error: error);
     }
   );
+}
+
+Future<Exception?> _initServices(bool bubble, List<String> arguments) async {
+  return await _captureError(() async {
+    await StartupTasks.initStartupServices(isBubble: bubble);
+    StartupTasks.onStartup().then((_) {
+      Logger.info("Startup tasks completed");
+    }).catchError((e, s) {
+      Logger.error("Failed to complete startup tasks!", error: e, trace: s);
+    });
+    await initializeDateFormatting();
+    MediaKit.ensureInitialized();
+    if (!ss.settings.finishedSetup.value && !kIsWeb && !kIsDesktop) {
+      runApp(MaterialApp(
+          home: SplashScreen(shouldNavigate: false),
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSwatch(
+                backgroundColor:
+                    PlatformDispatcher.instance.platformBrightness == Brightness.dark ? Colors.black : Colors.white),
+          )));
+    }
+    fs.checkFont();
+  }, "Failure during app initialization!");
+}
+
+Future<Exception?> _initTimezone() async {
+  return await _captureError(() async {
+    tz.initializeTimeZones();
+    try {
+      tz.setLocalLocation(tz.getLocation(await FlutterTimezone.getLocalTimezone()));
+    } catch (_) {}
+    if (!await EntityExtractorModelManager().isModelDownloaded(EntityExtractorLanguage.english.name)) {
+      EntityExtractorModelManager().downloadModel(EntityExtractorLanguage.english.name, isWifiRequired: false);
+    }
+  }, "Time zone initialization failed");
+}
+
+Future<Exception?> _initDesktopWindow(List<String> arguments) async {
+  return await _captureError(() async {
+    await windowManager.ensureInitialized();
+    await windowManager.setPreventClose(ss.settings.closeToTray.value);
+    await windowManager.setTitle('BlueBubbles');
+    await Window.initialize();
+    if (Platform.isWindows) {
+      await Window.hideWindowControls();
+    } else if (Platform.isLinux) {
+      await windowManager
+          .setTitleBarStyle(ss.settings.useCustomTitleBar.value ? TitleBarStyle.hidden : TitleBarStyle.normal);
+    }
+    windowManager.addListener(DesktopWindowListener.instance);
+    doWhenWindowReady(() async {
+      await windowManager.setMinimumSize(const Size(300, 300));
+      Display primary = await ScreenRetriever.instance.getPrimaryDisplay();
+
+      Size size = await windowManager.getSize();
+      double width = ss.prefs.getDouble("window-width") ?? size.width;
+      double height = ss.prefs.getDouble("window-height") ?? size.height;
+
+      width = width.clamp(300, max(300, primary.size.width));
+      height = height.clamp(300, max(300, primary.size.height));
+      await windowManager.setSize(Size(width, height));
+      await ss.prefs.setDouble("window-width", width);
+      await ss.prefs.setDouble("window-height", height);
+
+      await windowManager.setAlignment(Alignment.center);
+      Offset offset = await windowManager.getPosition();
+      double? posX = ss.prefs.getDouble("window-x") ?? offset.dx;
+      double? posY = ss.prefs.getDouble("window-y") ?? offset.dy;
+
+      posX = posX.clamp(0, max(0, primary.size.width - width));
+      posY = posY.clamp(0, max(0, primary.size.height - height));
+      await windowManager.setPosition(Offset(posX, posY), animate: true);
+      await ss.prefs.setDouble("window-x", posX);
+      await ss.prefs.setDouble("window-y", posY);
+
+      await windowManager.setTitle('BlueBubbles');
+      if (arguments.firstOrNull != "minimized") {
+        await windowManager.show();
+      }
+      if (!(ss.canAuthenticate && ss.settings.shouldSecure.value)) {
+        chats.init();
+        socket;
+      }
+    });
+    await dotenv.load(fileName: '.env', isOptional: true);
+  }, "Desktop initialization failed");
+}
+
+void _initTheme() {
+  ThemeData light = ThemeStruct.getLightTheme().data;
+  ThemeData dark = ThemeStruct.getDarkTheme().data;
+
+  final tuple = ts.getStructsFromData(light, dark);
+  light = tuple.item1;
+  dark = tuple.item2;
+
+  runApp(Main(
+    lightTheme: light,
+    darkTheme: dark,
+  ));
+}
+
+Future<Exception?> _captureError(Future<void> Function() f, String msg) async {
+  try {
+    await f();
+    return null;
+  } catch (e, s) {
+    Logger.error(msg, error: e, trace: s);
+    return Exception(msg);
+  }
 }
 
 class DesktopWindowListener extends WindowListener {

--- a/test/startup_integration_test.dart
+++ b/test/startup_integration_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/main.dart' as app;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('main startup', () async {
+    expect(app.initializeApp(false, []), completes);
+  });
+
+  test('bubble startup', () async {
+    expect(app.initializeApp(true, []), completes);
+  });
+}


### PR DESCRIPTION
## Summary
- modularize app initialization into _initServices, _initTimezone, and _initDesktopWindow helpers
- handle startup errors via _captureError helper
- add basic integration tests for main and bubble startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5507a4548331a3eb924a894c8e7d