### PR TITLE
Handle FaceTime links on web

### DIFF
--- a/lib/services/backend/java_dart_interop/intents_service.dart
+++ b/lib/services/backend/java_dart_interop/intents_service.dart
@@ -112,6 +112,11 @@ class IntentsService extends GetxService {
     }
   }
 
+  /// Generates a FaceTime link for the provided [callUuid] and attempts to open it.
+  ///
+  /// On mobile and desktop platforms the link is launched using the system's
+  /// external application handler. On web a new tab is opened, and if the link
+  /// cannot be launched a friendly message is shown to the user.
   Future<void> answerFaceTime(String callUuid) async {
     if (Get.context != null) {
       showDialog(
@@ -150,10 +155,13 @@ class IntentsService extends GetxService {
       return showSnackbar("Failed to answer FaceTime", "Unable to generate FaceTime link!");
     }
 
-    if (!kIsWeb) {
+    if (kIsWeb) {
+      final uri = Uri.parse(link);
+      if (!await launchUrl(uri)) {
+        showSnackbar("Failed to open FaceTime", "Your browser couldn't open the FaceTime link.");
+      }
+    } else {
       await launchUrl(Uri.parse(link), mode: LaunchMode.externalApplication);
-    } else if (kIsWeb) {
-      // TODO: Implement web FaceTime
     }
   }
 


### PR DESCRIPTION
## Summary
- handle FaceTime answer flow on web by launching the generated link or warning the user
- clarify cross-platform FaceTime behavior in `IntentsService`

## Testing
- `dart format lib/services/backend/java_dart_interop/intents_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad57c504a88331ab6d56d8c9091381