### PR TITLE
Remove unused .env asset reference

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -290,7 +290,6 @@ flutter:
     - assets/badges/badge-8.ico
     - assets/badges/badge-9.ico
     - assets/badges/badge-10.ico
-    - .env
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
   # For details regarding adding assets from package dependencies, see


### PR DESCRIPTION
## Summary
- Remove `.env` from `assets` section of `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --dart-define=ENABLE_FLOOD_TEST=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad581b802c833195f33c8583c50b3d