### PR TITLE
feat: gate socket stress test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
-      - run: flutter test --dart-define=ENABLE_FLOOD_TEST=true
+      - run: flutter test --tags integration --dart-define=ENABLE_FLOOD_TEST=true

--- a/test/socket_service_test.dart
+++ b/test/socket_service_test.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 import 'package:bluebubbles/services/network/socket_service.dart';
 
 /// Environment flag to enable the socket stress tests.
-const bool runSocketStressTest = bool.fromEnvironment('ENABLE_FLOOD_TEST', defaultValue: true);
+const bool runSocketStressTest = bool.fromEnvironment('ENABLE_FLOOD_TEST', defaultValue: false);
 
 class MockSocket {
   final Map<String, Function> _handlers = {};
@@ -50,11 +50,8 @@ class TestSocketService extends SocketService {
   }
 }
 
+@Tags(['integration'])
 void main() {
-  if (!runSocketStressTest) {
-    return;
-  }
-
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('SocketService handles disconnect during message flood', () async {
@@ -73,6 +70,6 @@ void main() {
     // Verify that all responses completed and the state reflects disconnect
     expect(responses.length, 50);
     expect(service.state.value, SocketState.disconnected);
-  });
+  }, skip: !runSocketStressTest);
 }
 


### PR DESCRIPTION
## Summary
- skip socket stress test unless ENABLE_FLOOD_TEST is explicitly set
- mark stress test as integration and run it only when requested in CI

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5a2702808331bd9f37b4c244de4f