### PR TITLE
Use secure storage for guidAuthKey

### DIFF
--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/ExternalIntentReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/ExternalIntentReceiver.kt
@@ -7,6 +7,8 @@ import android.util.Log
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodChannel
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 
 /// Receives intents from other apps. This is primarily used for Tasker integration.
 class ExternalIntentReceiver: BroadcastReceiver() {
@@ -19,7 +21,23 @@ class ExternalIntentReceiver: BroadcastReceiver() {
                 val password = intent.extras?.getString("password")
                 val identifier = intent.extras?.getString("id")
                 val prefs = context.getSharedPreferences("FlutterSharedPreferences", 0)
-                val storedPassword = prefs.getString("flutter.guidAuthKey", "")
+                val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+                val securePrefs = EncryptedSharedPreferences.create(
+                    "FlutterSecureStorage",
+                    masterKeyAlias,
+                    context,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
+                var storedPassword = securePrefs.getString("guidAuthKey", null)
+                if (storedPassword == null) {
+                    val legacy = prefs.getString("flutter.guidAuthKey", null)
+                    if (legacy != null) {
+                        securePrefs.edit().putString("guidAuthKey", legacy).apply()
+                        prefs.edit().remove("flutter.guidAuthKey").apply()
+                        storedPassword = legacy
+                    }
+                }
 
                 if (password == storedPassword) {
                     Utils.getServerUrl(context, object : MethodChannel.Result {

--- a/lib/services/backend/settings/settings_service.dart
+++ b/lib/services/backend/settings/settings_service.dart
@@ -37,7 +37,7 @@ class SettingsService extends GetxService {
 
   Future<void> init({bool headless = false}) async {
     prefs = await SharedPreferences.getInstance();
-    settings = Settings.getSettings();
+    settings = await Settings.getSettings();
     if (!headless && !kIsWeb && !kIsDesktop) {
       // refresh rate
       try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   flutter_map: ^7.0.1
   flutter_map_marker_popup: ^7.0.0
   flutter_markdown: ^0.7.2+1
+  flutter_secure_storage: ^9.0.0
   flutter_slidable: ^3.1.0
   flutter_staggered_grid_view: ^0.7.0
   flutter_svg: ^2.0.10+1


### PR DESCRIPTION
## Summary
- migrate guidAuthKey from SharedPreferences to flutter_secure_storage
- read/write guidAuthKey through secure storage with legacy key migration
- update Android services to use encrypted shared preferences

## Testing
- `apt-get update` *(fails: repository not signed)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5b882c9883319eb6e8d7e6eccd32