### PR TITLE
feat(crypto): harden encryption

### DIFF
--- a/lib/database/global/server_payload.dart
+++ b/lib/database/global/server_payload.dart
@@ -52,7 +52,7 @@ class ServerPayload {
   }) {
     if (isEncrypted) {
       if (encryptionType == EncryptionType.AES_PB) {
-        data = decryptAESCryptoJS(data, ss.settings.guidAuthKey.value);
+        data = decryptAES(data, ss.settings.guidAuthKey.value);
       }
     }
     if ([PayloadEncoding.JSON_OBJECT, PayloadEncoding.JSON_STRING].contains(encoding) && data is String) {

--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -148,7 +148,7 @@ class SocketService extends GetxService {
 
     socket.emitWithAck(event, message, ack: (response) {
       if (response['encrypted'] == true) {
-        response['data'] = jsonDecode(decryptAESCryptoJS(response['data'], password));
+        response['data'] = jsonDecode(decryptAES(response['data'], password));
       }
 
       if (!completer.isCompleted) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -632,14 +632,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.9"
-  encrypt:
-    dependency: "direct main"
-    description:
-      name: encrypt
-      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.3"
   equatable:
     dependency: transitive
     description:
@@ -2283,7 +2275,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pointycastle:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pointycastle
       sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   easy_debounce: ^2.0.3
   emojis: ^0.9.9
   emoji_picker_flutter: ^3.0.0
-  encrypt: ^5.0.3
+  pointycastle: ^3.7.3
   exif: ^3.3.0
   faker: ^2.1.0
   fast_contacts: ^4.0.0  # mobile only


### PR DESCRIPTION
## Summary
- switch AES routines to GCM
- derive keys using PBKDF2 with high iteration count
- update socket and payload handlers for new crypto helpers

## Testing
- `dart format lib/utils/crypto_utils.dart lib/services/network/socket_service.dart lib/database/global/server_payload.dart pubspec.yaml`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5b87250c8331a1eee5414cd15a00