### PR TITLE
Add explicit certificate trust control and logging

### DIFF
--- a/lib/app/layouts/settings/pages/server/server_management_panel.dart
+++ b/lib/app/layouts/settings/pages/server/server_management_panel.dart
@@ -569,6 +569,23 @@ class _ServerManagementPanelState extends CustomState<ServerManagementPanel, voi
                           socket.restartSocket();
                         }
                       }),
+                  const SettingsDivider(),
+                  Obx(() => SettingsSwitch(
+                        initialVal: ss.settings.trustSelfSignedCerts.value,
+                        title: "Trust Self-Signed Certificates",
+                        subtitle: "Allow connections to servers with self-signed SSL certificates",
+                        backgroundColor: tileColor,
+                        onChanged: (bool val) async {
+                          ss.settings.trustSelfSignedCerts.value = val;
+                          ss.saveSettings();
+                          socket.restartSocket();
+                        },
+                        leading: const SettingsLeadingIcon(
+                          iosIcon: CupertinoIcons.exclamationmark_shield,
+                          materialIcon: Icons.shield,
+                          containerColor: Colors.orange,
+                        ),
+                      )),
                   if (Platform.isAndroid)
                     const SettingsDivider(),
                   if (Platform.isAndroid)

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -18,6 +18,7 @@ class Settings {
   final RxString guidAuthKey = "".obs;
   final RxString serverAddress = "".obs;
   final RxMap<String, String> customHeaders = <String, String>{}.obs;
+  final RxBool trustSelfSignedCerts = false.obs;
   final RxBool finishedSetup = false.obs;
   final RxBool reachedConversationList = false.obs;
   final RxBool autoDownload = true.obs;
@@ -385,6 +386,7 @@ class Settings {
         'guidAuthKey': guidAuthKey.value,
         'serverAddress': serverAddress.value,
         'customHeaders': customHeaders,
+        'trustSelfSignedCerts': trustSelfSignedCerts.value,
         'finishedSetup': finishedSetup.value,
         'reachedConversationList': reachedConversationList.value,
         'colorsFromMedia': colorsFromMedia.value,
@@ -443,6 +445,7 @@ class Settings {
     ss.settings.tabletMode.value = kIsDesktop || (map['tabletMode'] ?? true);
     ss.settings.immersiveMode.value = map['immersiveMode'] ?? false;
     ss.settings.avatarScale.value = map['avatarScale']?.toDouble() ?? 1.0;
+    ss.settings.trustSelfSignedCerts.value = map['trustSelfSignedCerts'] ?? false;
     ss.settings.launchAtStartup.value = map['launchAtStartup'] ?? false;
     ss.settings.launchAtStartupMinimized.value = map['launchAtStartupMinimized'] ?? false;
     ss.settings.closeToTray.value = map['closeToTray'] ?? true;
@@ -537,6 +540,7 @@ class Settings {
     s.guidAuthKey.value = map['guidAuthKey'] ?? "";
     s.serverAddress.value = map['serverAddress'] ?? "";
     s.customHeaders.value = _processCustomHeaders(map['customHeaders']);
+    s.trustSelfSignedCerts.value = map['trustSelfSignedCerts'] ?? false;
     s.finishedSetup.value = map['finishedSetup'] ?? false;
     s.autoDownload.value = map['autoDownload'] ?? true;
     s.autoSave.value = map['autoSave'] ?? false;

--- a/lib/services/network/http_overrides.dart
+++ b/lib/services/network/http_overrides.dart
@@ -1,4 +1,6 @@
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:universal_io/io.dart';
 
 bool hasBadCert = false;
@@ -18,7 +20,13 @@ class BadCertOverride extends HttpOverrides {
         } else {
           hasBadCert = serverUrl.endsWith(host);
         }
-        return hasBadCert;
+
+        if (hasBadCert && !ss.settings.trustSelfSignedCerts.value) {
+          Logger.error("Untrusted certificate for $host", tag: "BadCertOverride");
+          showSnackbar("Certificate Error", "The certificate presented by $host is not trusted.");
+        }
+
+        return hasBadCert && ss.settings.trustSelfSignedCerts.value;
       };
   }
 }


### PR DESCRIPTION
## Summary
- require explicit trust before accepting self-signed certificates
- add user setting and UI toggle for trusting self-signed certificates
- log and notify when certificate errors occur

## Testing
- `dart format lib/services/network/http_overrides.dart lib/database/global/settings.dart lib/app/layouts/settings/pages/server/server_management_panel.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad5b86903083318a8830f7f401b0fa