### PR TITLE
Default sanitizeServerAddress to HTTPS and warn on HTTP URLs

### DIFF
--- a/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
+++ b/lib/app/layouts/setup/dialogs/manual_entry_dialog.dart
@@ -213,7 +213,7 @@ class _ManualEntryDialogState extends OptimizedState<ManualEntryDialog> {
             if (mounted) {
               setState(() {
                 error =
-                "Failed to connect to ${sanitizeServerAddress()}! Please check that the url is correct (including http://) and the server logs for more info.";
+                "Failed to connect to ${sanitizeServerAddress()}! Please check that the url is correct (including the protocol) and the server logs for more info.";
               });
             }
           }

--- a/lib/helpers/backend/settings_helpers.dart
+++ b/lib/helpers/backend/settings_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:bluebubbles/helpers/backend/foreground_service_helpers.dart';
 import 'package:bluebubbles/helpers/network/network_helpers.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:disable_battery_optimization/disable_battery_optimization.dart';
@@ -39,6 +40,10 @@ Future<bool> saveNewServerUrl(
 
   if (force || addressChanged || flagsChanged) {
     ss.settings.serverAddress.value = sanitized;
+
+    if (Uri.tryParse(sanitized)?.scheme == 'http') {
+      showSnackbar('Warning', 'HTTP URLs are not secure. Consider using HTTPS.');
+    }
 
     await ss.settings.saveMany(saveKeys);
 

--- a/lib/helpers/network/network_helpers.dart
+++ b/lib/helpers/network/network_helpers.dart
@@ -6,7 +6,7 @@ import 'package:universal_io/io.dart';
 
 /// Take the passed [address] or serverAddress from Settings
 /// and sanitize it, ensuring it includes an HTTP or HTTPS scheme.
-/// Uses HTTPS for ngrok.io, trycloudflare.com, and zrok.io addresses; otherwise HTTP.
+/// HTTPS is used by default unless the user explicitly provides an HTTP scheme.
 String? sanitizeServerAddress({String? address}) {
   String serverAddress = address ?? http.origin;
 
@@ -15,11 +15,7 @@ String? sanitizeServerAddress({String? address}) {
 
   Uri? uri = Uri.tryParse(sanitized);
   if (uri?.scheme.isEmpty ?? false) {
-    if (sanitized.contains("ngrok.io") || sanitized.contains("trycloudflare.com") || sanitized.contains("zrok.io")) {
-      uri = Uri.tryParse("https://$sanitized");
-    } else {
-      uri = Uri.tryParse("http://$sanitized");
-    }
+    uri = Uri.tryParse("https://$sanitized");
   }
 
   return uri.toString();

--- a/test/network_helpers_test.dart
+++ b/test/network_helpers_test.dart
@@ -3,17 +3,22 @@ import 'package:bluebubbles/helpers/network/network_helpers.dart';
 
 void main() {
   group('sanitizeServerAddress', () {
-    test('adds http prefix for plain host', () {
+    test('defaults to https for plain host', () {
       final result = sanitizeServerAddress(address: 'example.com');
+      expect(result, 'https://example.com');
+    });
+
+    test('retains http when explicitly provided', () {
+      final result = sanitizeServerAddress(address: 'http://example.com');
       expect(result, 'http://example.com');
     });
 
-    test('adds https prefix for ngrok host', () {
+    test('uses https for ngrok host', () {
       final result = sanitizeServerAddress(address: 'my-ngrok.ngrok.io');
       expect(result, 'https://my-ngrok.ngrok.io');
     });
 
-    test('adds https prefix for zrok host', () {
+    test('uses https for zrok host', () {
       final result = sanitizeServerAddress(address: 'my-zrok.zrok.io');
       expect(result, 'https://my-zrok.zrok.io');
     });


### PR DESCRIPTION
## Summary
- Default `sanitizeServerAddress` to HTTPS unless `http://` is explicitly provided.
- Warn users when saving an HTTP server URL.
- Clarify protocol wording in setup dialog and expand tests.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5b8636b88331999194901c923a10