### PR TITLE
feat: add notification quick reply

### DIFF
--- a/lib/helpers/types/helpers/message_helper.dart
+++ b/lib/helpers/types/helpers/message_helper.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
@@ -101,7 +102,11 @@ class MessageHelper {
     if (ls.isAlive && cm.isChatActive(chat.guid)) return;
     // if app is alive, on chat list, but notifying on chat list is disabled
     if (ls.isAlive && cm.activeChat == null && Get.rawRoute?.settings.name == "/" && !ss.settings.notifyOnChatList.value) return;
-    await notif.createNotification(chat, message);
+    await notif.createNotification(
+      chat,
+      message,
+      payload: jsonEncode({'chatGuid': chat.guid}),
+    );
   }
 
   static Future<void> handleSummaryNotification(List<Message> messages, {bool findExisting = true}) async {


### PR DESCRIPTION
## Summary
- add reply action to generated notifications
- handle input actions from notifications and forward to message send logic
- include chat identifiers when building notifications for quick reply

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5ea837b48331bcfcfafb0d154651