### PR TITLE
feat: use high-speed connection for full quality images

### DIFF
--- a/lib/helpers/network/network_helpers.dart
+++ b/lib/helpers/network/network_helpers.dart
@@ -3,6 +3,7 @@ import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:universal_io/io.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
 /// Take the passed [address] or serverAddress from Settings
 /// and sanitize it, ensuring it includes an HTTP or HTTPS scheme.
@@ -60,4 +61,14 @@ Future<String> getDeviceName() async {
   }
 
   return deviceName;
+}
+
+Future<bool> isHighSpeedConnection() async {
+  try {
+    final results = await Connectivity().checkConnectivity();
+    return results.contains(ConnectivityResult.wifi) ||
+        results.contains(ConnectivityResult.ethernet);
+  } catch (_) {
+    return false;
+  }
 }

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -6,6 +6,7 @@ import 'package:bluebubbles/app/components/custom_text_editing_controllers.dart'
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:emojis/emoji.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -201,7 +202,12 @@ class ConversationViewController extends StatefulController with GetSingleTicker
         tmpData = file.bytes;
       }
     } else if (attachment.canCompress) {
-      tmpData = await as.loadAndGetProperties(attachment, actualPath: file.path!);
+      if (await isHighSpeedConnection()) {
+        tmpData = await File(file.path!).readAsBytes();
+        await as.loadDimensions(attachment, filePath: file.path!, data: tmpData);
+      } else {
+        tmpData = await as.loadAndGetProperties(attachment, actualPath: file.path!);
+      }
       // All other attachments can be held in memory as bytes
     } else {
       tmpData = await File(file.path!).readAsBytes();


### PR DESCRIPTION
## Summary
- add `isHighSpeedConnection` helper
- extract image dimensions without re-encoding
- bypass compression on high-speed connections in `_processNextImage`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad60b5ea808331a628946f6bbee3bf