### PR TITLE
Document original attachment download parameter

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -547,8 +547,9 @@ class _MessagePopupState extends OptimizedState<MessagePopup> with SingleTickerP
     try {
       for (Attachment? element in toDownload) {
         attachmentObs.value = element;
-        final response = await http.downloadAttachment(element!.guid!,
-            original: true, onReceiveProgress: (count, total) => progress.value = kIsWeb ? (count / total) : (count / element.totalBytes!));
+        final response = await http.downloadAttachmentOriginal(element!.guid!,
+            onReceiveProgress: (count, total) => progress.value =
+                kIsWeb ? (count / total) : (count / element.totalBytes!));
         final file = PlatformFile(
           name: element.transferName!,
           size: response.data.length,

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -278,8 +278,16 @@ class HttpService extends GetxService {
     });
   }
 
-  /// Get the attachment data for the specified [guid]
-  Future<Response> downloadAttachment(String guid, {void Function(int, int)? onReceiveProgress, bool original = false, CancelToken? cancelToken}) async {
+  /// Get the attachment data for the specified [guid].
+  ///
+  /// The [original] flag determines whether the server should return the
+  /// full-resolution, uncompressed version of the attachment rather than any
+  /// optimized variant that may normally be served. This is useful when the
+  /// client explicitly requests the exact file that was sent.
+  Future<Response> downloadAttachment(String guid,
+      {void Function(int, int)? onReceiveProgress,
+      bool original = false,
+      CancelToken? cancelToken}) async {
     return runApiGuarded(() async {
       final response = await dio.get(
           "$apiRoot/attachment/$guid/download",
@@ -290,6 +298,17 @@ class HttpService extends GetxService {
       );
       return returnSuccessOrError(response);
     });
+  }
+
+  /// Convenience helper for [downloadAttachment] that always requests the
+  /// original attachment data.
+  Future<Response> downloadAttachmentOriginal(String guid,
+      {void Function(int, int)? onReceiveProgress,
+      CancelToken? cancelToken}) async {
+    return downloadAttachment(guid,
+        onReceiveProgress: onReceiveProgress,
+        original: true,
+        cancelToken: cancelToken);
   }
 
   /// Get the live photo data for the specified [guid]

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -260,7 +260,14 @@ class AttachmentsService extends GetxService {
     }
   }
 
-  Future<void> redownloadAttachment(Attachment attachment, {Function(PlatformFile)? onComplete, Function()? onError}) async {
+  /// Delete any existing local copies and download the attachment again.
+  ///
+  /// When [original] is set to `true`, the uncompressed version of the
+  /// attachment will be downloaded from the server.
+  Future<void> redownloadAttachment(Attachment attachment,
+      {Function(PlatformFile)? onComplete,
+      Function()? onError,
+      bool original = false}) async {
     if (!kIsWeb) {
       final file = File(attachment.path);
       final pngFile = File(attachment.convertedPath);
@@ -275,11 +282,14 @@ class AttachmentsService extends GetxService {
       } catch(_) {}
     }
 
-    Get.put(AttachmentDownloadController(
-        attachment: attachment,
-        onComplete: (file) => onComplete?.call(file),
-        onError: onError
-    ), tag: attachment.guid);
+    Get.put(
+        AttachmentDownloadController(
+          attachment: attachment,
+          onComplete: (file) => onComplete?.call(file),
+          onError: onError,
+          original: original,
+        ),
+        tag: attachment.guid);
   }
 
   Future<Size> getImageSizing(String filePath, Attachment attachment) async {


### PR DESCRIPTION
## Summary
- document `original` flag in `downloadAttachment`
- propagate `original` through download services and add helper `downloadAttachmentOriginal`
- allow attachment re-download to request original file

## Testing
- `dart format lib/services/network/http_service.dart lib/services/network/downloads_service.dart lib/services/ui/attachments_service.dart lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad60b608e88331a9f0741e0178c693