### PR TITLE
Specify RxInt type for count in CustomService

### DIFF
--- a/lib/services/custom_service.dart
+++ b/lib/services/custom_service.dart
@@ -1,7 +1,7 @@
 import 'package:get/get.dart';
 
 class CustomService extends GetxService {
-  final count = 0.obs;
+  final RxInt count = 0.obs;
 
   void increment() => count.value++;
 


### PR DESCRIPTION
## Summary
- specify `RxInt` type for `CustomService.count`

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ad60fd03548331806cfde8140ea0df