### PR TITLE
Enable lint rules for prints and single quotes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,8 +22,8 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-  # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-  # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+  avoid_print: true
+  prefer_single_quotes: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -209,8 +209,8 @@ class BulkSaveNewMessages extends AsyncTask<List<dynamic>, List<Message>> {
     if (messagesToUpdate.isNotEmpty) {
       try {
         Database.messages.putMany(messagesToUpdate.values.toList());
-      } catch (ex) {
-        print('Failed to put associated messages into DB: ${ex.toString()}');
+      } catch (ex, st) {
+        Logger.error('Failed to put associated messages into DB', error: ex, trace: st);
       }
     }
   }

--- a/lib/services/custom_service.dart
+++ b/lib/services/custom_service.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:get/get.dart';
 
 class CustomService extends GetxService {
@@ -8,12 +9,12 @@ class CustomService extends GetxService {
   @override
   void onInit() {
     super.onInit();
-    print('CustomService initialized');
+    Logger.info('CustomService initialized');
   }
 
   @override
   void onClose() {
-    print('CustomService disposed');
+    Logger.info('CustomService disposed');
     super.onClose();
   }
 }

--- a/test/startup_tasks_stress_test.dart
+++ b/test/startup_tasks_stress_test.dart
@@ -3,6 +3,7 @@
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 
@@ -47,8 +48,8 @@ void main() {
       }
       stopwatch.stop();
       // Output memory usage for manual inspection
-      print('Memory usage (RSS): $memUsage');
-      print('Total elapsed: ${stopwatch.elapsed}');
+      debugPrint('Memory usage (RSS): $memUsage');
+      debugPrint('Total elapsed: ${stopwatch.elapsed}');
     });
 
     test('concurrent initialization', () async {


### PR DESCRIPTION
## Summary
- enable avoid_print and prefer_single_quotes lint rules
- replace prints with Logger or debugPrint

## Testing
- ⚠️ `flutter analyze` *(failed: command not found)*
- ⚠️ `dart analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad61006e008331834bbd4f9261c2f0