### PR TITLE
feat: add sticker sending

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/text_field/picked_attachment.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/picked_attachment.dart
@@ -150,6 +150,7 @@ class _PickedAttachmentState extends OptimizedState<PickedAttachment> with Autom
                             onPressed: () {
                               if (widget.controller != null) {
                                 widget.controller!.pickedAttachments.removeWhere((e) => e.path == widget.data.path);
+                                widget.controller!.pickedStickers.removeWhere((e) => e.path == widget.data.path);
                                 widget.controller!.chat.textFieldAttachments.removeWhere((e) => e == widget.data.path);
                                 widget.controller!.chat.save(updateTextFieldAttachments: true);
                               } else {
@@ -187,6 +188,7 @@ class _PickedAttachmentState extends OptimizedState<PickedAttachment> with Autom
                 onPressed: () {
                   if (widget.controller != null) {
                     widget.controller!.pickedAttachments.removeWhere((e) => e.path == widget.data.path);
+                    widget.controller!.pickedStickers.removeWhere((e) => e.path == widget.data.path);
                     widget.controller!.chat.textFieldAttachments.removeWhere((e) => e == widget.data.path);
                     widget.controller!.chat.save(updateTextFieldAttachments: true);
                   } else {

--- a/lib/database/global/queue_items.dart
+++ b/lib/database/global/queue_items.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:bluebubbles/database/models.dart';
 
-enum QueueType {newMessage, updatedMessage, sendMessage, sendAttachment, sendMultipart}
+enum QueueType {newMessage, updatedMessage, sendMessage, sendAttachment, sendMultipart, sendSticker}
 
 abstract class QueueItem {
   QueueType type;

--- a/lib/services/backend/queue/outgoing_queue.dart
+++ b/lib/services/backend/queue/outgoing_queue.dart
@@ -21,6 +21,8 @@ class OutgoingQueue extends Queue {
         return await ah.prepMessage(item.chat, item.message, item.selected, item.reaction, clearNotificationsIfFromMe: !(item.customArgs?['notifReply'] ?? false));
       case QueueType.sendAttachment:
         return await ah.prepAttachment(item.chat, item.message);
+      case QueueType.sendSticker:
+        return await ah.prepSticker(item.chat, item.message);
       default:
         Logger.info("Unhandled queue event: ${item.type.name}");
         break;
@@ -66,6 +68,9 @@ class OutgoingQueue extends Queue {
         break;
       case QueueType.sendAttachment:
         await handleSend(() => ah.sendAttachment(item.chat, item.message, item.customArgs?['audio'] ?? false), item.chat);
+        break;
+      case QueueType.sendSticker:
+        await handleSend(() => ah.sendSticker(item.chat, item.message), item.chat);
         break;
       default:
         Logger.info("Unhandled queue event: ${item.type.name}");

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -714,6 +714,34 @@ class HttpService extends GetxService {
     });
   }
 
+  /// Send a sticker. [chatGuid] specifies the chat, [tempGuid] specifies a
+  /// temporary guid to avoid duplicate messages being sent, [file] is the
+  /// sticker image, and [selectedMessageGuid] is the guid of the message being
+  /// stickered.
+  Future<Response> sendSticker(String chatGuid, String tempGuid, PlatformFile file, String selectedMessageGuid, {int? partIndex, void Function(int, int)? onSendProgress, CancelToken? cancelToken}) async {
+    return runApiGuarded(() async {
+      final fileName = file.name;
+      final formData = FormData.fromMap({
+        "sticker": kIsWeb ? MultipartFile.fromBytes(file.bytes!, filename: fileName) : await MultipartFile.fromFile(file.path!, filename: fileName),
+        "chatGuid": chatGuid,
+        "tempGuid": tempGuid,
+        "name": fileName,
+        "selectedMessageGuid": selectedMessageGuid,
+        "partIndex": partIndex,
+      });
+
+      final response = await dio.post(
+          "$apiRoot/message/sticker",
+          queryParameters: buildQueryParams(),
+          cancelToken: cancelToken,
+          data: formData,
+          onSendProgress: onSendProgress,
+          options: Options(sendTimeout: dio.options.sendTimeout! * 12, receiveTimeout: dio.options.receiveTimeout! * 12, headers: headers),
+      );
+      return returnSuccessOrError(response);
+    });
+  }
+
   /// Send a message. [chatGuid] specifies the chat, [tempGuid] specifies a
   /// temporary guid to avoid duplicate messages being sent, [message] is the
   /// body of the message. Optionally provide [method] to send via private API,

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -62,6 +62,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   RxBool showEmojiPicker = false.obs;
   final GlobalKey textFieldKey = GlobalKey();
   final RxList<PlatformFile> pickedAttachments = <PlatformFile>[].obs;
+  final RxList<PlatformFile> pickedStickers = <PlatformFile>[].obs;
   final focusNode = FocusNode();
   final subjectFocusNode = FocusNode();
   late final textController = MentionTextEditingController(focusNode: focusNode);


### PR DESCRIPTION
## Summary
- add sticker picker and sending logic in conversation text field
- support sendSticker API and queue handling
- persist user sent stickers for display

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62f078bc8331b9ecd4e2f91cf5c3