### PR TITLE
refactor: remove deprecated Future<Null> return types

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,19 +52,16 @@ bool isAuthing = false;
 final systemTray = st.SystemTray();
 
 @pragma('vm:entry-point')
-//ignore: prefer_void_to_null
-Future<Null> main(List<String> arguments) async {
+Future<void> main(List<String> arguments) async {
   await initializeApp(false, arguments);
 }
 
 @pragma('vm:entry-point')
-// ignore: prefer_void_to_null
-Future<Null> bubble() async {
+Future<void> bubble() async {
   await initializeApp(true, []);
 }
 
-//ignore: prefer_void_to_null
-Future<Null> initializeApp(bool bubble, List<String> arguments) async {
+Future<void> initializeApp(bool bubble, List<String> arguments) async {
   runZonedGuarded<Future<void>>(
     () async {
       WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Summary
- replace deprecated `Future<Null>` with `Future<void>` in entry point methods

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2961072c8331a42ebf6afb1ae724