### PR TITLE
refactor: remove test code and async logger

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,8 +22,8 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-  # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-  # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    avoid_print: true
+    prefer_single_quotes: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
@@ -206,14 +206,14 @@ class _TroubleshootPanelState extends OptimizedState<TroubleshootPanel> {
 
                           try {
                             showSnackbar("Please Wait", "Compressing ${logFileCount.value} log file(s)...");
-                            String filePath = Logger.compressLogs();
+                            String filePath = await Logger.compressLogs();
                             final File zippedLogFile = File(filePath);
 
                             // Copy the file to downloads
                             String newPath = await fs.saveToDownloads(zippedLogFile);
 
                             // Delete the original file
-                            zippedLogFile.deleteSync();
+                            await zippedLogFile.delete();
 
                             // Let the user know what happened
                             showSnackbar(
@@ -258,7 +258,7 @@ class _TroubleshootPanelState extends OptimizedState<TroubleshootPanel> {
                       title: "Clear Logs",
                       subtitle: "Deletes all stored log files.",
                       onTap: () async {
-                        Logger.clearLogs();
+                        await Logger.clearLogs();
                         showSnackbar(
                             "Logs Cleared", "All logs have been deleted.");
                         logFileCount.value = 0;

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -3,7 +3,6 @@ import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart' hide Response, FormData, MultipartFile;
 
 /// Get an instance of our [HttpService]
@@ -90,8 +89,6 @@ class HttpService extends GetxService {
       headers: headers,
     ));
     dio.interceptors.add(ApiInterceptor());
-    // Uncomment to run tests on most API requests
-    // testAPI();
     super.onInit();
   }
 
@@ -1324,131 +1321,6 @@ class HttpService extends GetxService {
     }, checkOrigin: false);
   }
 
-  /// Test most API GET requests (the ones that don't have required parameters)
-  void testAPI() {
-    Stopwatch s = Stopwatch();
-    group("API Service Test", () {
-      test("Ping", () async {
-        s.start();
-        var res = await ping();
-        expect(res.data['message'], "pong");
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Server Info", () async {
-        s.start();
-        var res = await serverInfo();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Server Stat Totals", () async {
-        s.start();
-        var res = await serverStatTotals();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Server Stat Media", () async {
-        s.start();
-        var res = await serverStatMedia();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Server Logs", () async {
-        s.start();
-        var res = await serverLogs();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("FCM Client", () async {
-        s.start();
-        var res = await fcmClient();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Attachment Count", () async {
-        s.start();
-        var res = await attachmentCount();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Chats", () async {
-        s.start();
-        var res = await chats();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Chat Count", () async {
-        s.start();
-        var res = await chatCount();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Message Count", () async {
-        s.start();
-        var res = await messageCount();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("My Message Count", () async {
-        s.start();
-        var res = await messageCount(onlyMe: true);
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Messages", () async {
-        s.start();
-        var res = await messages();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Handle Count", () async {
-        s.start();
-        var res = await handleCount();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("iCloud Contacts", () async {
-        s.start();
-        var res = await contacts();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Theme Backup", () async {
-        s.start();
-        var res = await getTheme();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Settings Backup", () async {
-        s.start();
-        var res = await getSettings();
-        expect(res.data['status'], 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-      test("Landing Page", () async {
-        s.start();
-        var res = await landingPage();
-        expect(res.statusCode, 200);
-        s.stop();
-        Logger.info("Request took ${s.elapsedMilliseconds} ms");
-      });
-    });
-  }
 }
 
 /// Intercepts API requests, responses, and errors and logs them to console

--- a/lib/utils/logger/logger.dart
+++ b/lib/utils/logger/logger.dart
@@ -212,14 +212,16 @@ class BaseLogger extends GetxService {
     _logger = createLogger();
   }
 
-  String compressLogs() {
+  Future<String> compressLogs() async {
     final Directory logDir = Directory(Logger.logDir);
     final date = DateTime.now().toIso8601String().split('T').first;
     final File zippedLogFile =
         File("${fs.appDocDir.path}/bluebubbles-logs-$date.zip");
-    if (zippedLogFile.existsSync()) zippedLogFile.deleteSync();
+    if (await zippedLogFile.exists()) {
+      await zippedLogFile.delete();
+    }
 
-    final List<FileSystemEntity> files = logDir.listSync();
+    final List<FileSystemEntity> files = await logDir.list().toList();
     final List<FileSystemEntity> logFiles =
         files.where((file) => file.path.endsWith(".log")).toList();
     final List<String> logPaths = logFiles.map((file) => file.path).toList();
@@ -236,9 +238,9 @@ class BaseLogger extends GetxService {
 
   Future<List<String>> getLogs({maxLines = 1000}) async {
     final Directory logDir = Directory(Logger.logDir);
-    if (!logDir.existsSync()) return [];
+    if (!await logDir.exists()) return [];
 
-    final List<FileSystemEntity> files = logDir.listSync();
+    final List<FileSystemEntity> files = await logDir.list().toList();
     final List<FileSystemEntity> logFiles =
         files.where((file) => file.path.endsWith(latestLogName)).toList();
     if (logFiles.isEmpty) return [];
@@ -270,13 +272,13 @@ class BaseLogger extends GetxService {
     return logs;
   }
 
-  void clearLogs() {
+  Future<void> clearLogs() async {
     final Directory logDir = Directory(Logger.logDir);
-    if (!logDir.existsSync()) return;
+    if (!await logDir.exists()) return;
 
-    for (final file in logDir.listSync()) {
+    await for (final file in logDir.list()) {
       if (file is File) {
-        file.deleteSync();
+        await file.delete();
       }
     }
   }

--- a/test/utils/logger_test.dart
+++ b/test/utils/logger_test.dart
@@ -46,7 +46,7 @@ void main() {
     final logFile = File(join(logDir.path, Logger.latestLogName));
     await logFile.writeAsString('2024-01-01 [INFO] log');
 
-    final zipPath = Logger.compressLogs();
+    final zipPath = await Logger.compressLogs();
     final zipFile = File(zipPath);
     expect(zipFile.existsSync(), isTrue);
 
@@ -54,12 +54,12 @@ void main() {
     expect(archive.files.any((f) => f.name.endsWith('.log')), isTrue);
   });
 
-  test('clearLogs removes existing logs', () {
+  test('clearLogs removes existing logs', () async {
     final logFile = File(join(logDir.path, Logger.latestLogName));
     logFile.writeAsStringSync('test log');
     expect(logDir.listSync().isNotEmpty, isTrue);
 
-    Logger.clearLogs();
+    await Logger.clearLogs();
     expect(logDir.listSync(), isEmpty);
   });
 }


### PR DESCRIPTION
## Summary
- remove `flutter_test` import and embedded API tests from `HttpService`
- enable stricter lint rules
- refactor logger to use async file I/O and update callers/tests

## Testing
- `dart format analysis_options.yaml lib/services/network/http_service.dart lib/utils/logger/logger.dart lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart test/utils/logger_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2aa26318833194b1bb71c465a648