### PR TITLE
Handle timezone and model download errors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -121,12 +121,24 @@ Future<Exception?> _initTimezone() async {
     tz.initializeTimeZones();
     try {
       tz.setLocalLocation(tz.getLocation(await FlutterTimezone.getLocalTimezone()));
-    } catch (_) {}
+    } catch (e, s) {
+      Logger.error("Failed to set local timezone", error: e, trace: s);
+      rethrow;
+    }
     if (!await EntityExtractorModelManager().isModelDownloaded(EntityExtractorLanguage.english.name)) {
-      EntityExtractorModelManager().downloadModel(EntityExtractorLanguage.english.name, isWifiRequired: false);
+      try {
+        await EntityExtractorModelManager()
+            .downloadModel(EntityExtractorLanguage.english.name, isWifiRequired: false);
+      } catch (e, s) {
+        Logger.error("Failed to download entity extraction model", error: e, trace: s);
+        rethrow;
+      }
     }
   }, "Time zone initialization failed");
 }
+
+@visibleForTesting
+Future<Exception?> testInitTimezone() => _initTimezone();
 
 Future<Exception?> _initDesktopWindow(List<String> arguments) async {
   return await _captureError(() async {

--- a/test/init_timezone_test.dart
+++ b/test/init_timezone_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/main.dart' as app;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const timezoneChannel = MethodChannel('flutter_timezone');
+  const entityChannel = MethodChannel('google_mlkit_entity_extractor');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(timezoneChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(entityChannel, null);
+  });
+
+  test('timezone failure surfaces', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      timezoneChannel,
+      (MethodCall call) async => 'Invalid/Timezone',
+    );
+
+    final exception = await app.testInitTimezone();
+    expect(exception, isNotNull);
+  });
+
+  test('model download failure surfaces', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      timezoneChannel,
+      (MethodCall call) async => 'America/Detroit',
+    );
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      entityChannel,
+      (MethodCall call) async {
+        if (call.method == 'isModelDownloaded') return false;
+        if (call.method == 'downloadModel') {
+          throw PlatformException(code: 'failed', message: 'download failed');
+        }
+        return null;
+      },
+    );
+
+    final exception = await app.testInitTimezone();
+    expect(exception, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- log and rethrow timezone errors during initialization
- await and handle entity extractor model download failures
- test initialization error paths for timezone and model download

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3dd793748331bc1732c63dde8ca1