### PR TITLE
Log startup task errors during initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,11 +96,13 @@ Future<void> initializeApp(bool bubble, List<String> arguments) async {
 Future<Exception?> _initServices(bool bubble, List<String> arguments) async {
   return await _captureError(() async {
     await StartupTasks.initStartupServices(isBubble: bubble);
-    StartupTasks.onStartup().then((_) {
+    try {
+      await StartupTasks.onStartup();
       Logger.info("Startup tasks completed");
-    }).catchError((e, s) {
+    } catch (e, s) {
       Logger.error("Failed to complete startup tasks!", error: e, trace: s);
-    });
+      rethrow;
+    }
     await initializeDateFormatting();
     MediaKit.ensureInitialized();
     if (!ss.settings.finishedSetup.value && !kIsWeb && !kIsDesktop) {

--- a/test/startup_integration_test.dart
+++ b/test/startup_integration_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bluebubbles/main.dart' as app;
+import 'package:bluebubbles/helpers/backend/startup_tasks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -10,5 +11,13 @@ void main() {
 
   test('bubble startup', () async {
     expect(app.initializeApp(true, []), completes);
+  });
+
+  test('startup failure halts initialization', () async {
+    StartupTasks.onStartupOverride = () async {
+      throw Exception('startup failed');
+    };
+    await expectLater(app.initializeApp(false, []), throwsException);
+    StartupTasks.onStartupOverride = null;
   });
 }


### PR DESCRIPTION
## Summary
- replace then/catchError with awaited try/catch in `initializeApp`
- expose `StartupTasks.onStartupOverride` and rethrow logged failures
- add integration test ensuring initialization halts when startup tasks fail

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3dd53d9883319dfdc91909e6703c