### PR TITLE
Use regex to parse Windows build number

### DIFF
--- a/lib/app/layouts/settings/pages/theming/theming_panel.dart
+++ b/lib/app/layouts/settings/pages/theming/theming_panel.dart
@@ -214,7 +214,7 @@ class _ThemingPanelState extends CustomState<ThemingPanel, void, ThemingPanelCon
                             saveSettings();
                           },
                           title: "Window Effect",
-                          subtitle: "${WindowEffects.descriptions[ss.settings.windowEffect.value]}\n\nOperating System Version: ${Platform.operatingSystemVersion}\nBuild number: ${parsedWindowsVersion()}${parsedWindowsVersion() < 22000 && ss.settings.windowEffect.value == WindowEffect.acrylic ? "\n\n⚠️ This effect causes window movement lag on Windows 10" : ""}",
+                          subtitle: "${WindowEffects.descriptions[ss.settings.windowEffect.value]}\n\nOperating System Version: ${Platform.operatingSystemVersion}\nBuild number: ${parsedWindowsVersion() ?? 'Unknown'}${(parsedWindowsVersion() ?? 0) < 22000 && ss.settings.windowEffect.value == WindowEffect.acrylic ? "\n\n⚠️ This effect causes window movement lag on Windows 10" : ""}",
                           secondaryColor: headerColor,
                           capitalize: true,
                         ),
@@ -222,7 +222,7 @@ class _ThemingPanelState extends CustomState<ThemingPanel, void, ThemingPanelCon
                       if (ss.settings.skin.value == Skins.iOS)
                         Obx(() => SettingsSubtitle(
                               unlimitedSpace: true,
-                              subtitle: "${WindowEffects.descriptions[ss.settings.windowEffect.value]}\n\nOperating System Version: ${Platform.operatingSystemVersion}\nBuild number: ${parsedWindowsVersion()}${parsedWindowsVersion() < 22000 && ss.settings.windowEffect.value == WindowEffect.acrylic ? "\n\n⚠️ This effect causes window movement lag on Windows 10" : ""}",
+                              subtitle: "${WindowEffects.descriptions[ss.settings.windowEffect.value]}\n\nOperating System Version: ${Platform.operatingSystemVersion}\nBuild number: ${parsedWindowsVersion() ?? 'Unknown'}${(parsedWindowsVersion() ?? 0) < 22000 && ss.settings.windowEffect.value == WindowEffect.acrylic ? "\n\n⚠️ This effect causes window movement lag on Windows 10" : ""}",
                         )),
                       Obx(() {
                         if (WindowEffects.dependsOnColor() && !WindowEffects.isDark(color: context.theme.colorScheme.background)) {

--- a/lib/utils/window_effects.dart
+++ b/lib/utils/window_effects.dart
@@ -29,7 +29,10 @@ class WindowEffects {
 
   static List<WindowEffect> get effects =>
       _effects.where((effect) {
-        int version = parsedWindowsVersion();
+        int? version = parsedWindowsVersion();
+        if (version == null) {
+          return _versions[effect]!.item1 == 0;
+        }
         return version >= _versions[effect]!.item1! &&
             (_versions[effect]!.item2 == null || (version <= _versions[effect]!.item2!));
       }).toList();
@@ -103,7 +106,7 @@ class WindowEffects {
     if (!effects.contains(effect)) ss.settings.windowEffect.value = WindowEffect.disabled;
     ss.saveSettings(ss.settings);
 
-    bool supportsTransparentAcrylic = parsedWindowsVersion() >= 22000;
+    bool supportsTransparentAcrylic = (parsedWindowsVersion() ?? 0) >= 22000;
     bool addOpacity = ss.settings.windowEffect.value == WindowEffect.acrylic && !supportsTransparentAcrylic;
 
     // withOpacity uses withAlpha((255.0 * opacity).round());
@@ -118,7 +121,9 @@ class WindowEffects {
   }
 }
 
-int parsedWindowsVersion() {
-  String raw = Platform.operatingSystemVersion;
-  return int.tryParse(raw.substring(raw.indexOf("Build") + 6, raw.length - 1)) ?? 0;
+int? parsedWindowsVersion([String? raw]) {
+  raw ??= Platform.operatingSystemVersion;
+  final match = RegExp(r'Build\s*(\d+)').firstMatch(raw);
+  if (match == null) return null;
+  return int.tryParse(match.group(1)!);
 }

--- a/test/utils/window_effects_test.dart
+++ b/test/utils/window_effects_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bluebubbles/utils/window_effects.dart';
+
+void main() {
+  group('parsedWindowsVersion', () {
+    test('parses typical build number', () {
+      expect(
+        parsedWindowsVersion('Windows 10 Pro 10.0 (Build 19045.2846)'),
+        19045,
+      );
+    });
+
+    test('parses windows 11 build number', () {
+      expect(
+        parsedWindowsVersion('Microsoft Windows 10.0 (Build 22621)'),
+        22621,
+      );
+    });
+
+    test('returns null for unexpected format', () {
+      expect(parsedWindowsVersion('Microsoft Windows [Version 10.0.19045.3324]'), isNull);
+      expect(parsedWindowsVersion('Unknown Format'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Safely extract Windows build using RegExp and return null on failure
- Guard window effect availability when build number can't be parsed
- Cover typical and malformed OS version strings with unit tests

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3dc9a14c833188f71376cf7b3680