### PR TITLE
chore: build generated files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
           flutter pub upgrade --major-versions
           flutter pub get
 
+      - name: Build generated files
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Ensure generated files are committed
+        run: |
+          git status --porcelain
+          test -z "$(git status --porcelain)"
+
       - name: Analyze
         run: flutter analyze
 


### PR DESCRIPTION
## Summary
- run build_runner during CI to generate files
- ensure workflow fails if code generation changes tracked files

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3cdbd8d883318009af9ae9586d29