### PR TITLE
chore: use flutter pub get in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,8 @@ jobs:
           flutter --version
           dart --version
 
-      - name: Pub upgrade & get
-        run: |
-          flutter pub upgrade --major-versions
-          flutter pub get
+      - name: Install dependencies
+        run: flutter pub get
 
       - name: Analyze
         run: flutter analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Resolve dependencies (respect dependency_overrides)
         run: |
-          flutter pub upgrade --major-versions
           flutter pub get
           flutter pub deps --style=compact | sed -n '1,120p'
 


### PR DESCRIPTION
## Summary
- use `flutter pub get` in CI and tests workflows to respect locked versions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3cd6bf6c8331ae597b16d6eb9702