### PR TITLE
refactor reactions to enum

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -176,7 +176,10 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
     super.build(context);
     controller.built = true;
     final stickers = message.associatedMessages.where((e) => e.associatedMessageType == "sticker");
-    final reactions = message.associatedMessages.where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")));
+    final reactions = message.associatedMessages
+        .where((e) =>
+            ReactionTypes.fromString(e.associatedMessageType?.replaceAll("-", "")) !=
+            null);
     Iterable<Message> stickersForPart(int part) {
       return stickers.where((s) => (s.associatedMessagePart ?? 0) == part);
     }

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup_holder.dart
@@ -111,7 +111,7 @@ class _MessagePopupHolderState extends OptimizedState<MessagePopupHolder> {
 
   void sendTapback([String? type, int? part]) {
     HapticFeedback.lightImpact();
-    final reaction = type ?? ss.settings.quickTapbackType.value;
+    final reaction = type ?? ss.settings.quickTapbackType.value.name;
     Logger.info("Sending reaction type: $reaction");
     outq.queue(OutgoingItem(
       type: QueueType.sendMessage,

--- a/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
@@ -39,7 +39,8 @@ class ReactionWidgetState extends OptimizedState<ReactionWidget> {
   List<Message>? get reactions => widget.reactions;
   bool get reactionIsFromMe => reaction.isFromMe!;
   bool get messageIsFromMe => widget.message?.isFromMe ?? true;
-  String get reactionType => reaction.associatedMessageType!;
+  ReactionType get reactionType =>
+      ReactionTypes.fromString(reaction.associatedMessageType!.replaceAll('-', ''))!;
 
   static const double iosSize = 35;
 
@@ -161,7 +162,7 @@ class ReactionWidgetState extends OptimizedState<ReactionWidget> {
                     textAlign: TextAlign.center,
                   );
                   // rotate thumbs down to match iOS
-                  if (reactionType == "dislike") {
+                    if (reactionType == ReactionType.dislike) {
                     return Transform(
                       transform: Matrix4.identity()..rotateY(pi),
                       alignment: FractionalOffset.center,
@@ -207,10 +208,11 @@ class ReactionWidgetState extends OptimizedState<ReactionWidget> {
               height: iosSize*0.8,
               child: Center(
                 child: Padding(
-                  padding: const EdgeInsets.all(6.5).add(EdgeInsets.only(right: reactionType == "emphasize" ? 1 : 0)),
+                  padding: const EdgeInsets.all(6.5)
+                      .add(EdgeInsets.only(right: reactionType == ReactionType.emphasize ? 1 : 0)),
                   child: SvgPicture.asset(
-                    'assets/reactions/$reactionType-black.svg',
-                    colorFilter: ColorFilter.mode(reactionType == "love"
+                    'assets/reactions/${reactionType.name}-black.svg',
+                    colorFilter: ColorFilter.mode(reactionType == ReactionType.love
                         ? Colors.pink
                         : (reactionIsFromMe ? context.theme.colorScheme.onPrimary : context.theme.colorScheme.properOnSurface), BlendMode.srcIn),
                   ),

--- a/lib/app/layouts/settings/pages/advanced/private_api_panel.dart
+++ b/lib/app/layouts/settings/pages/advanced/private_api_panel.dart
@@ -242,7 +242,7 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                             show: ss.settings.enableQuickTapback.value,
                             child: Padding(
                               padding: const EdgeInsets.only(bottom: 5.0),
-                              child: SettingsOptions<String>(
+                              child: SettingsOptions<ReactionType>(
                                 title: "Quick Tapback",
                                 options: ReactionTypes.toList(),
                                 cupertinoCustomWidgets: [
@@ -251,8 +251,8 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.LOVE,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.LOVE),
+                                          associatedMessageType: ReactionType.love.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.love),
                                       message: null,
                                     ),
                                   ),
@@ -261,8 +261,8 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.LIKE,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.LIKE),
+                                          associatedMessageType: ReactionType.like.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.like),
                                       message: null,
                                     ),
                                   ),
@@ -271,8 +271,8 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.DISLIKE,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.DISLIKE),
+                                          associatedMessageType: ReactionType.dislike.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.dislike),
                                       message: null,
                                     ),
                                   ),
@@ -281,8 +281,8 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.LAUGH,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.LAUGH),
+                                          associatedMessageType: ReactionType.laugh.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.laugh),
                                       message: null,
                                     ),
                                   ),
@@ -291,8 +291,8 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.EMPHASIZE,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.EMPHASIZE),
+                                          associatedMessageType: ReactionType.emphasize.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.emphasize),
                                       message: null,
                                     ),
                                   ),
@@ -301,14 +301,14 @@ class _PrivateAPIPanelState extends CustomState<PrivateAPIPanel, void, PrivateAP
                                     child: ReactionWidget(
                                       reaction: Message(
                                           guid: "",
-                                          associatedMessageType: ReactionTypes.QUESTION,
-                                          isFromMe: ss.settings.quickTapbackType.value != ReactionTypes.QUESTION),
+                                          associatedMessageType: ReactionType.question.name,
+                                          isFromMe: ss.settings.quickTapbackType.value != ReactionType.question),
                                       message: null,
                                     ),
                                   ),
                                 ],
                                 initial: ss.settings.quickTapbackType.value,
-                                textProcessing: (val) => val,
+                                textProcessing: (val) => val.name,
                                 onChanged: (val) {
                                   if (val == null) return;
                                   ss.settings.quickTapbackType.value = val;

--- a/lib/app/layouts/settings/pages/desktop/desktop_panel.dart
+++ b/lib/app/layouts/settings/pages/desktop/desktop_panel.dart
@@ -268,7 +268,9 @@ class _DesktopPanelState extends OptimizedState<DesktopPanel> {
                                                       child: Material(
                                                         color: Colors.transparent,
                                                         child: Text(
-                                                          ReactionTypes.reactionToEmoji[value] ?? "Mark Read",
+                                                          ReactionTypes.reactionToEmoji[
+                                                                ReactionTypes.fromString(value)!] ??
+                                                              "Mark Read",
                                                           style: TextStyle(
                                                               fontSize: 16,
                                                               color: (hardDisabled && value == "Mark Read")
@@ -438,7 +440,8 @@ class _DesktopPanelState extends OptimizedState<DesktopPanel> {
                                                               index == markReadIndex
                                                                   ? ss.settings.actionList[index]
                                                                   : ReactionTypes.reactionToEmoji[
-                                                                      ss.settings.actionList[index]]!,
+                                                                      ReactionTypes.fromString(
+                                                                          ss.settings.actionList[index])!]!,
                                                               style: context.textTheme.bodyMedium!
                                                                   .copyWith(fontSize: size * 0.037),
                                                               textAlign: TextAlign.center,

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -129,7 +129,7 @@ class Settings {
 
   // Quick tapback settings
   final RxBool enableQuickTapback = false.obs;
-  final RxString quickTapbackType = ReactionTypes.toList()[0].obs; // The 'love' reaction
+  final Rx<ReactionType> quickTapbackType = ReactionType.love.obs; // The 'love' reaction
 
   // Slideable action settings
   final Rx<MaterialSwipeAction> materialRightAction = MaterialSwipeAction.pin.obs;
@@ -173,12 +173,12 @@ class Settings {
   final RxList<int> selectedActionIndices = Platform.isWindows ? [0, 1, 2, 3, 4].obs : [0, 1, 2].obs;
   final RxList<String> actionList = RxList.from([
     "Mark Read",
-    ReactionTypes.LOVE,
-    ReactionTypes.LIKE,
-    ReactionTypes.LAUGH,
-    ReactionTypes.EMPHASIZE,
-    ReactionTypes.DISLIKE,
-    ReactionTypes.QUESTION
+    ReactionType.love.name,
+    ReactionType.like.name,
+    ReactionType.laugh.name,
+    ReactionType.emphasize.name,
+    ReactionType.dislike.name,
+    ReactionType.question.name
   ]);
 
   // Message options order
@@ -383,7 +383,7 @@ class Settings {
       'generateFakeContactNames': generateFakeContactNames.value,
       'generateFakeMessageContent': hideMessageContent.value,
       'enableQuickTapback': enableQuickTapback.value,
-      'quickTapbackType': quickTapbackType.value,
+      'quickTapbackType': quickTapbackType.value.name,
       'materialRightAction': materialRightAction.value.index,
       'materialLeftAction': materialLeftAction.value.index,
       'shouldSecure': shouldSecure.value,
@@ -520,7 +520,8 @@ class Settings {
     ss.settings.enableUnifiedPush.value = map['enableUnifiedPush'] ?? false;
     ss.settings.endpointUnifiedPush.value = map['endpointUnifiedPush'] ?? "";
     ss.settings.enableQuickTapback.value = map['enableQuickTapback'] ?? false;
-    ss.settings.quickTapbackType.value = map['quickTapbackType'] ?? ReactionTypes.toList()[0];
+    ss.settings.quickTapbackType.value =
+        ReactionTypes.fromString(map['quickTapbackType']) ?? ReactionType.love;
     ss.settings.materialRightAction.value = map['materialRightAction'] != null
         ? MaterialSwipeAction.values[map['materialRightAction']]
         : MaterialSwipeAction.pin;
@@ -668,7 +669,8 @@ class Settings {
     s.enableUnifiedPush.value = map['enableUnifiedPush'] ?? false;
     s.endpointUnifiedPush.value = map['endpointUnifiedPush'] ?? "";
     s.enableQuickTapback.value = map['enableQuickTapback'] ?? false;
-    s.quickTapbackType.value = map['quickTapbackType'] ?? ReactionTypes.toList()[0];
+    s.quickTapbackType.value =
+        ReactionTypes.fromString(map['quickTapbackType']) ?? ReactionType.love;
     s.materialRightAction.value = map['materialRightAction'] != null
         ? MaterialSwipeAction.values[map['materialRightAction']]
         : MaterialSwipeAction.pin;
@@ -748,12 +750,12 @@ List<String> _processActionList(dynamic rawJson) {
     debugPrint("Using default actionList");
     return [
       "Mark Read",
-      ReactionTypes.LOVE,
-      ReactionTypes.LIKE,
-      ReactionTypes.LAUGH,
-      ReactionTypes.EMPHASIZE,
-      ReactionTypes.DISLIKE,
-      ReactionTypes.QUESTION
+      ReactionType.love.name,
+      ReactionType.like.name,
+      ReactionType.laugh.name,
+      ReactionType.emphasize.name,
+      ReactionType.dislike.name,
+      ReactionType.question.name
     ];
   }
 }

--- a/lib/database/html/chat.dart
+++ b/lib/database/html/chat.dart
@@ -264,7 +264,7 @@ class Chat {
       return true;
     }
     return !ss.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.fromString(message?.associatedMessageType) != null;
   }
 
   static void unDelete(Chat chat) {

--- a/lib/database/html/message.dart
+++ b/lib/database/html/message.dart
@@ -370,8 +370,11 @@ class Message {
 
   List<Attachment> get previewAttachments => attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
-  List<Message> get reactions => associatedMessages.where((item) =>
-      ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", ""))).toList();
+  List<Message> get reactions => associatedMessages
+      .where((item) => ReactionTypes.fromString(
+              item.associatedMessageType?.replaceAll("-", "")) !=
+          null)
+      .toList();
 
   Indicator get indicatorToShow {
     if (!isFromMe!) return Indicator.NONE;

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -596,7 +596,7 @@ class Chat {
 
     /// If reaction and notify reactions off, then don't notify, otherwise notify
     return !ss.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.fromString(message?.associatedMessageType) != null;
   }
 
   /// Delete a chat locally. Prefer using softDelete so the chat doesn't come back

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -838,8 +838,11 @@ class Message {
 
   List<Attachment> get previewAttachments => attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
-  List<Message> get reactions => associatedMessages.where((item) =>
-      ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", ""))).toList();
+  List<Message> get reactions => associatedMessages
+      .where((item) => ReactionTypes.fromString(
+              item.associatedMessageType?.replaceAll("-", "")) !=
+          null)
+      .toList();
 
   Indicator get indicatorToShow {
     if (!isFromMe!) return Indicator.NONE;

--- a/lib/helpers/types/helpers/message_helper.dart
+++ b/lib/helpers/types/helpers/message_helper.dart
@@ -176,7 +176,8 @@ class MessageHelper {
       Message? associatedMessage = Message.findOne(guid: message.associatedMessageGuid);
       if (associatedMessage != null) {
         // grab the verb we'll use from the reactionToVerb map
-        String? verb = ReactionTypes.reactionToVerb[message.associatedMessageType];
+        String? verb =
+            ReactionTypes.getVerb(message.associatedMessageType ?? "");
         // we need to check balloonBundleId first because for some reason
         // game pigeon messages have the text "�"
         if (associatedMessage.isInteractive) {
@@ -271,7 +272,7 @@ class MessageHelper {
     List<Message> normalized = [];
 
     for (Message message in associatedMessages.reversed.toList()) {
-      if (!ReactionTypes.toList().contains(message.associatedMessageType)) {
+      if (ReactionTypes.fromString(message.associatedMessageType) == null) {
         normalized.add(message);
       } else if (guids.remove(message.guid)) {
         normalized.add(message);

--- a/lib/helpers/ui/reaction_helpers.dart
+++ b/lib/helpers/ui/reaction_helpers.dart
@@ -2,63 +2,58 @@ import 'package:bluebubbles/database/models.dart' hide Entity;
 import 'package:emojis/emojis.dart';
 import 'package:flutter/foundation.dart';
 
-class ReactionTypes {
-  // ignore: non_constant_identifier_names
-  static const String LOVE = "love";
-  // ignore: non_constant_identifier_names
-  static const String LIKE = "like";
-  // ignore: non_constant_identifier_names
-  static const String DISLIKE = "dislike";
-  // ignore: non_constant_identifier_names
-  static const String LAUGH = "laugh";
-  // ignore: non_constant_identifier_names
-  static const String EMPHASIZE = "emphasize";
-  // ignore: non_constant_identifier_names
-  static const String QUESTION = "question";
+enum ReactionType { love, like, dislike, laugh, emphasize, question }
 
-  static List<String> toList() {
-    return [
-      LOVE,
-      LIKE,
-      DISLIKE,
-      LAUGH,
-      EMPHASIZE,
-      QUESTION,
-    ];
+class ReactionTypes {
+  static List<ReactionType> toList() {
+    return ReactionType.values;
   }
 
-  static final Map<String, String> reactionToVerb = {
-    LOVE: "loved",
-    LIKE: "liked",
-    DISLIKE: "disliked",
-    LAUGH: "laughed at",
-    EMPHASIZE: "emphasized",
-    QUESTION: "questioned",
-    "-$LOVE": "removed a heart from",
-    "-$LIKE": "removed a like from",
-    "-$DISLIKE": "removed a dislike from",
-    "-$LAUGH": "removed a laugh from",
-    "-$EMPHASIZE": "removed an exclamation from",
-    "-$QUESTION": "removed a question mark from",
+  static ReactionType? fromString(String? type) {
+    if (type == null) return null;
+    try {
+      return ReactionType.values.firstWhere((e) => e.name == type);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static final Map<ReactionType, String> reactionToVerb = {
+    ReactionType.love: "loved",
+    ReactionType.like: "liked",
+    ReactionType.dislike: "disliked",
+    ReactionType.laugh: "laughed at",
+    ReactionType.emphasize: "emphasized",
+    ReactionType.question: "questioned",
   };
 
-  static final Map<String, String> reactionToEmoji = {
-    LOVE: Emojis.redHeart,
-    LIKE: Emojis.thumbsUp,
-    DISLIKE: Emojis.thumbsDown,
-    LAUGH: Emojis.faceWithTearsOfJoy,
-    EMPHASIZE: Emojis.redExclamationMark,
-    QUESTION: Emojis.redQuestionMark,
+  static final Map<ReactionType, String> negativeReactionToVerb = {
+    ReactionType.love: "removed a heart from",
+    ReactionType.like: "removed a like from",
+    ReactionType.dislike: "removed a dislike from",
+    ReactionType.laugh: "removed a laugh from",
+    ReactionType.emphasize: "removed an exclamation from",
+    ReactionType.question: "removed a question mark from",
   };
 
-  static final Map<String, String> emojiToReaction = {
-    Emojis.redHeart: LOVE,
-    Emojis.thumbsUp: LIKE,
-    Emojis.thumbsDown: DISLIKE,
-    Emojis.faceWithTearsOfJoy: LAUGH,
-    Emojis.redExclamationMark: EMPHASIZE,
-    Emojis.redQuestionMark: QUESTION,
+  static final Map<ReactionType, String> reactionToEmoji = {
+    ReactionType.love: Emojis.redHeart,
+    ReactionType.like: Emojis.thumbsUp,
+    ReactionType.dislike: Emojis.thumbsDown,
+    ReactionType.laugh: Emojis.faceWithTearsOfJoy,
+    ReactionType.emphasize: Emojis.redExclamationMark,
+    ReactionType.question: Emojis.redQuestionMark,
   };
+
+  static final Map<String, ReactionType> emojiToReaction =
+      reactionToEmoji.map((key, value) => MapEntry(value, key));
+
+  static String? getVerb(String reaction) {
+    final negative = reaction.startsWith('-');
+    final type = fromString(reaction.replaceFirst('-', ''));
+    if (type == null) return null;
+    return negative ? negativeReactionToVerb[type] : reactionToVerb[type];
+  }
 }
 
 List<Message> getUniqueReactionMessages(List<Message> messages) {

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -375,7 +375,8 @@ class NotificationsService extends GetxService {
         .map((action) => action == "Mark Read"
             ? action
             : !isReaction && !message.isGroupEvent && papi
-                ? ReactionTypes.reactionToEmoji[action]!
+                ? ReactionTypes
+                    .reactionToEmoji[ReactionTypes.fromString(action)!]!
                 : null)
         .whereNotNull()
         .toList();
@@ -490,14 +491,15 @@ class NotificationsService extends GetxService {
           chat.toggleHasUnread(false);
           EventDispatcher().emit('refresh', null);
         } else if (ss.settings.enablePrivateAPI.value) {
-          String reaction = ReactionTypes.emojiToReaction[actions[index]]!;
+          ReactionType reaction =
+              ReactionTypes.emojiToReaction[actions[index]]!;
           outq.queue(
             OutgoingItem(
               type: QueueType.sendMessage,
               chat: chat,
               message: Message(
                 associatedMessageGuid: message.guid,
-                associatedMessageType: reaction,
+                associatedMessageType: reaction.name,
                 associatedMessagePart: 0,
                 dateCreated: DateTime.now(),
                 hasAttachments: false,
@@ -505,7 +507,7 @@ class NotificationsService extends GetxService {
                 handleId: 0,
               ),
               selected: message,
-              reaction: reaction,
+              reaction: reaction.name,
             ),
           );
         }

--- a/lib/services/backend_ui_interop/intents.dart
+++ b/lib/services/backend_ui_interop/intents.dart
@@ -128,7 +128,7 @@ class HeartRecentAction extends Action<HeartRecentIntent> {
   Object? invoke(covariant HeartRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.LOVE);
+      _sendReactionHelper(chat, message, ReactionType.love);
     }
     return null;
   }
@@ -147,7 +147,7 @@ class LikeRecentAction extends Action<LikeRecentIntent> {
   Object? invoke(covariant LikeRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.LIKE);
+      _sendReactionHelper(chat, message, ReactionType.like);
     }
     return null;
   }
@@ -166,7 +166,7 @@ class DislikeRecentAction extends Action<DislikeRecentIntent> {
   Object? invoke(covariant DislikeRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.DISLIKE);
+      _sendReactionHelper(chat, message, ReactionType.dislike);
     }
     return null;
   }
@@ -185,7 +185,7 @@ class LaughRecentAction extends Action<LaughRecentIntent> {
   Object? invoke(covariant LaughRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.LAUGH);
+      _sendReactionHelper(chat, message, ReactionType.laugh);
     }
     return null;
   }
@@ -204,7 +204,7 @@ class EmphasizeRecentAction extends Action<EmphasizeRecentIntent> {
   Object? invoke(covariant EmphasizeRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.EMPHASIZE);
+      _sendReactionHelper(chat, message, ReactionType.emphasize);
     }
     return null;
   }
@@ -223,7 +223,7 @@ class QuestionRecentAction extends Action<QuestionRecentIntent> {
   Object? invoke(covariant QuestionRecentIntent intent) async {
     final message = ms(chat.guid).mostRecent;
     if (message != null && ss.settings.enablePrivateAPI.value) {
-      _sendReactionHelper(chat, message, ReactionTypes.QUESTION);
+      _sendReactionHelper(chat, message, ReactionType.question);
     }
     return null;
   }
@@ -339,19 +339,19 @@ class GoBackAction extends Action<GoBackIntent> {
   }
 }
 
-void _sendReactionHelper(Chat c, Message selected, String t) {
+void _sendReactionHelper(Chat c, Message selected, ReactionType t) {
   outq.queue(OutgoingItem(
     type: QueueType.sendMessage,
     chat: c,
     message: Message(
       associatedMessageGuid: selected.guid,
-      associatedMessageType: t,
+      associatedMessageType: t.name,
       dateCreated: DateTime.now(),
       hasAttachments: false,
       isFromMe: true,
       handleId: 0,
     ),
     selected: selected,
-    reaction: t,
+    reaction: t.name,
   ));
 }


### PR DESCRIPTION
## Summary
- add a dedicated `ReactionType` enum and mapping helpers
- update settings, widgets and services to use `ReactionType`
- remove non-constant identifier ignores

## Testing
- `dart format lib/helpers/ui/reaction_helpers.dart lib/database/global/settings.dart lib/database/io/chat.dart lib/database/io/message.dart lib/database/html/chat.dart lib/database/html/message.dart lib/helpers/types/helpers/message_helper.dart lib/services/backend/notifications/notifications_service.dart lib/services/backend_ui_interop/intents.dart lib/app/layouts/conversation_view/widgets/message/message_holder.dart lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart lib/app/layouts/conversation_view/widgets/message/popup/message_popup_holder.dart lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart lib/app/layouts/settings/pages/advanced/private_api_panel.dart lib/app/layouts/settings/pages/desktop/desktop_panel.dart` (command not found)
- `flutter test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae4084bc788331b29aab4330010303