### PR TITLE
chore: strengthen lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,23 +7,16 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-include: package:flutter_lints/flutter.yaml
+include: package:lints/core.yaml
 
 linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
   rules:
     avoid_print: true
     prefer_single_quotes: true
+    public_member_api_docs: true
+    unawaited_futures: true
+    prefer_final_fields: true
+    sort_pub_dependencies: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,6 @@ environment:
   sdk: '>=3.1.3 <4.0.0'
 
 dependencies:
-  flutter:
-    sdk: flutter
   adaptive_theme: ^3.6.0
   animated_size_and_fade: ^4.0.0
   animations: ^2.0.11
@@ -34,15 +32,17 @@ dependencies:
   fast_contacts: ^4.0.0
   file_picker: ^8.0.0+1
   firebase_core: ^3.3.0
-  firebase_messaging: ^15.0.4
   firebase_dart:
     git:
       url: https://github.com/appsup-dart/firebase_dart.git
       ref: beb79f70a2bb0e96e6bb9fdebac2ff452f138950
       path: package
+  firebase_messaging: ^15.0.4
   fixnum: ^1.1.0
   fl_chart: ^0.68.0
   flex_color_scheme: ^8.1.1
+  flutter:
+    sdk: flutter
   flutter_acrylic: ^1.1.4
   flutter_animate: ^4.5.0
   flutter_app_badger: ^1.5.0


### PR DESCRIPTION
## Summary
- switch to core lints and enable docs/async/final/pubsort rules
- sort pubspec dependencies to satisfy linting

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae40838d5883318a0e6f29cb8b8f2a