### PR TITLE
refactor: remove buildBackButton helper

### DIFF
--- a/lib/app/layouts/chat_creator/chat_creator.dart
+++ b/lib/app/layouts/chat_creator/chat_creator.dart
@@ -14,9 +14,9 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/string_utils.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
@@ -309,7 +309,7 @@ class ChatCreatorState extends OptimizedState<ChatCreator> {
             elevation: 0,
             scrolledUnderElevation: 3,
             surfaceTintColor: context.theme.colorScheme.primary,
-            leading: buildBackButton(context),
+            leading: const BackButton(),
             backgroundColor: Colors.transparent,
             centerTitle: ss.settings.skin.value == Skins.iOS,
             title: Text(

--- a/lib/app/layouts/chat_selector_view/chat_selector_view.dart
+++ b/lib/app/layouts/chat_selector_view/chat_selector_view.dart
@@ -6,7 +6,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
@@ -95,7 +95,7 @@ class ChatSelectorViewState extends OptimizedState<ChatSelectorView> {
                 elevation: 0,
                 scrolledUnderElevation: 3,
                 surfaceTintColor: context.theme.colorScheme.primary,
-                leading: buildBackButton(context),
+                leading: const BackButton(),
                 backgroundColor: Colors.transparent,
                 centerTitle: ss.settings.skin.value == Skins.iOS,
                 title: Text(

--- a/lib/app/layouts/contact_selector_view/contact_selector_view.dart
+++ b/lib/app/layouts/contact_selector_view/contact_selector_view.dart
@@ -6,7 +6,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
@@ -86,7 +86,7 @@ class ContactSelectorViewState extends OptimizedState<ContactSelectorView> {
                 elevation: 0,
                 scrolledUnderElevation: 3,
                 surfaceTintColor: context.theme.colorScheme.primary,
-                leading: buildBackButton(context),
+                leading: const BackButton(),
                 backgroundColor: Colors.transparent,
                 centerTitle: ss.settings.skin.value == Skins.iOS,
                 title: Text(

--- a/lib/app/layouts/conversation_list/pages/cupertino_conversation_list.dart
+++ b/lib/app/layouts/conversation_list/pages/cupertino_conversation_list.dart
@@ -10,7 +10,7 @@ import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
@@ -55,7 +55,7 @@ class CupertinoConversationListState extends OptimizedState<CupertinoConversatio
           : const SizedBox.shrink()),
       appBar: showArchived || showUnknown
           ? AppBar(
-              leading: buildBackButton(context),
+              leading: const BackButton(),
               elevation: 0,
               systemOverlayStyle: brightness == Brightness.dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
               centerTitle: true,

--- a/lib/app/layouts/conversation_list/widgets/header/samsung_header.dart
+++ b/lib/app/layouts/conversation_list/widgets/header/samsung_header.dart
@@ -4,7 +4,7 @@ import 'package:bluebubbles/app/layouts/conversation_list/widgets/header/header_
 import 'package:bluebubbles/app/layouts/conversation_list/pages/search/search_view.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
 
@@ -102,13 +102,7 @@ class _SamsungHeaderState extends CustomState<SamsungHeader, void, ConversationL
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           if (showArchived || showUnknown)
-                            IconButton(
-                                onPressed: () async {
-                                  Navigator.of(context).pop();
-                                },
-                                padding: EdgeInsets.zero,
-                                icon: buildBackButton(context)
-                            ),
+                            const BackButton(),
                           if (!showArchived && !showUnknown)
                             const SizedBox.shrink(),
                           Row(

--- a/lib/app/layouts/findmy/findmy_page.dart
+++ b/lib/app/layouts/findmy/findmy_page.dart
@@ -16,10 +16,10 @@ import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
 import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
@@ -930,7 +930,7 @@ class _FindMyPageState extends OptimizedState<FindMyPage> with SingleTickerProvi
                             width: 48,
                             height: 48,
                             margin: const EdgeInsets.symmetric(horizontal: 8),
-                            child: buildBackButton(context),
+                            child: const BackButton(),
                           ),
                           Expanded(child: Text("Find My", style: context.theme.textTheme.titleLarge)),
                         ],
@@ -1176,7 +1176,10 @@ class _FindMyPageState extends OptimizedState<FindMyPage> with SingleTickerProvi
                   child: Container(
                     width: 48,
                     height: 48,
-                    child: buildBackButton(context, padding: const EdgeInsets.only(right: 2)),
+                    child: const Padding(
+                      padding: EdgeInsets.only(right: 2),
+                      child: const BackButton(),
+                    ),
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color: Theme.of(context).colorScheme.properSurface.withOpacity(0.9),
@@ -1343,7 +1346,7 @@ class _FindMyPageState extends OptimizedState<FindMyPage> with SingleTickerProvi
                     height: 50,
                     child: Align(
                       alignment: Alignment.centerLeft,
-                      child: buildBackButton(context),
+                      child: const BackButton(),
                     ),
                   ),
                 ),

--- a/lib/app/layouts/handle_selector_view/handle_selector_view.dart
+++ b/lib/app/layouts/handle_selector_view/handle_selector_view.dart
@@ -8,7 +8,7 @@ import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/string_utils.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
@@ -128,7 +128,7 @@ class HandleSelectorViewState extends OptimizedState<HandleSelectorView> {
                 elevation: 0,
                 scrolledUnderElevation: 3,
                 surfaceTintColor: context.theme.colorScheme.primary,
-                leading: buildBackButton(context),
+                leading: const BackButton(),
                 backgroundColor: Colors.transparent,
                 centerTitle: ss.settings.skin.value == Skins.iOS,
                 title: Text(

--- a/lib/app/layouts/settings/pages/conversation_list/pinned_order_panel.dart
+++ b/lib/app/layouts/settings/pages/conversation_list/pinned_order_panel.dart
@@ -6,7 +6,7 @@ import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
@@ -49,7 +49,7 @@ class PinnedOrderPanel extends StatelessWidget {
                   elevation: 0,
                   scrolledUnderElevation: 3,
                   surfaceTintColor: context.theme.colorScheme.primary,
-                  leading: buildBackButton(context),
+                  leading: const BackButton(),
                   backgroundColor: _backgroundColor.value,
                   centerTitle: ss.settings.skin.value == Skins.iOS,
                   title: Text(

--- a/lib/app/layouts/settings/pages/message_view/message_options_order_panel.dart
+++ b/lib/app/layouts/settings/pages/message_view/message_options_order_panel.dart
@@ -6,7 +6,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/backend/settings/settings_service.dart';
 import 'package:bluebubbles/services/ui/navigator/navigator_service.dart';
 import 'package:bluebubbles/services/ui/theme/themes_service.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
 import 'package:get/get.dart';
@@ -60,7 +60,7 @@ class _MessageOptionsOrderPanelState extends OptimizedState<MessageOptionsOrderP
                   elevation: 0,
                   scrolledUnderElevation: 3,
                   surfaceTintColor: context.theme.colorScheme.primary,
-                  leading: buildBackButton(context),
+                  leading: const BackButton(),
                   backgroundColor: _backgroundColor.value,
                   centerTitle: ss.settings.skin.value == Skins.iOS,
                   title: Text(

--- a/lib/app/layouts/settings/pages/misc/about_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/about_panel.dart
@@ -7,10 +7,10 @@ import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:get/get.dart';
@@ -145,7 +145,7 @@ class _AboutPanelState extends OptimizedState<AboutPanel> {
                                 elevation: 0,
                                 scrolledUnderElevation: 3,
                                 surfaceTintColor: context.theme.colorScheme.primary,
-                                leading: buildBackButton(context),
+                                leading: const BackButton(),
                                 backgroundColor: headerColor,
                                 iconTheme: IconThemeData(color: context.theme.colorScheme.primary),
                                 centerTitle: iOS,

--- a/lib/app/layouts/settings/pages/misc/live_logging_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/live_logging_panel.dart
@@ -4,7 +4,7 @@ import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
@@ -104,7 +104,7 @@ class _LiveLoggingPanel extends State<LiveLoggingPanel> {
                     elevation: 0,
                     scrolledUnderElevation: 3,
                     surfaceTintColor: context.theme.colorScheme.primary,
-                    leading: buildBackButton(context),
+                    leading: const BackButton(),
                     backgroundColor: _backgroundColor.value,
                     centerTitle: ss.settings.skin.value == Skins.iOS,
                     title: Text(

--- a/lib/app/layouts/settings/pages/misc/logging_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/logging_panel.dart
@@ -4,7 +4,7 @@ import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:get/get.dart';
@@ -108,7 +108,7 @@ class _LoggingPanel extends State<LoggingPanel> {
                     elevation: 0,
                     scrolledUnderElevation: 3,
                     surfaceTintColor: context.theme.colorScheme.primary,
-                    leading: buildBackButton(context),
+                    leading: const BackButton(),
                     backgroundColor: _backgroundColor.value,
                     centerTitle: ss.settings.skin.value == Skins.iOS,
                     title: Text(

--- a/lib/app/layouts/settings/pages/system/notification_panel.dart
+++ b/lib/app/layouts/settings/pages/system/notification_panel.dart
@@ -8,9 +8,9 @@ import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:universal_html/html.dart' as uh;
@@ -198,7 +198,7 @@ class _NotificationPanelState extends OptimizedState<NotificationPanel> with Sin
             elevation: 0,
             scrolledUnderElevation: 3,
             surfaceTintColor: context.theme.colorScheme.primary,
-            leading: buildBackButton(context),
+            leading: const BackButton(),
             backgroundColor: headerColor,
             centerTitle: iOS,
             title: Text(
@@ -285,7 +285,7 @@ class _NotificationPanelState extends OptimizedState<NotificationPanel> with Sin
                                         height: 50,
                                         child: Align(
                                           alignment: Alignment.centerLeft,
-                                          child: buildBackButton(context),
+                                          child: const BackButton(),
                                         ),
                                       ),
                                     ),

--- a/lib/app/layouts/settings/pages/theming/advanced/advanced_theming_panel.dart
+++ b/lib/app/layouts/settings/pages/theming/advanced/advanced_theming_panel.dart
@@ -7,8 +7,8 @@ import 'package:bluebubbles/app/layouts/settings/pages/theming/advanced/advanced
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
@@ -66,7 +66,7 @@ class _AdvancedThemingPanelState extends OptimizedState<AdvancedThemingPanel> wi
             elevation: 0,
             scrolledUnderElevation: 3,
             surfaceTintColor: context.theme.colorScheme.primary,
-            leading: buildBackButton(context),
+            leading: const BackButton(),
             backgroundColor: headerColor,
             centerTitle: iOS,
             title: Text(

--- a/lib/app/layouts/settings/pages/theming/avatar/avatar_crop.dart
+++ b/lib/app/layouts/settings/pages/theming/avatar/avatar_crop.dart
@@ -4,7 +4,7 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:crop_your_image/crop_your_image.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:universal_io/io.dart';
@@ -91,7 +91,7 @@ class _AvatarCropState extends OptimizedState<AvatarCrop> {
               elevation: 0,
               scrolledUnderElevation: 3,
               surfaceTintColor: context.theme.colorScheme.primary,
-              leading: buildBackButton(context),
+              leading: const BackButton(),
               backgroundColor: headerColor,
               centerTitle: iOS,
               title: Text(

--- a/lib/app/layouts/settings/widgets/layout/settings_scaffold.dart
+++ b/lib/app/layouts/settings/widgets/layout/settings_scaffold.dart
@@ -3,7 +3,7 @@ import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
@@ -60,7 +60,7 @@ class SettingsScaffold extends StatelessWidget {
             elevation: 0,
             scrolledUnderElevation: 3,
             surfaceTintColor: context.theme.colorScheme.primary,
-            leading: buildBackButton(context),
+            leading: const BackButton(),
             backgroundColor: headerColor,
             centerTitle: ss.settings.skin.value == Skins.iOS,
             title: Text(
@@ -150,7 +150,7 @@ class SettingsScaffold extends StatelessWidget {
                                           height: 50,
                                           child: Align(
                                             alignment: Alignment.centerLeft,
-                                            child: buildBackButton(context),
+                                            child: const BackButton(),
                                           ),
                                         ),
                                       ),

--- a/lib/app/layouts/setup/pages/unfinished/theme_selector.dart
+++ b/lib/app/layouts/setup/pages/unfinished/theme_selector.dart
@@ -5,7 +5,7 @@ import 'package:bluebubbles/helpers/ui/ui_helpers.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
@@ -771,7 +771,7 @@ Widget buildConversationViewHeader(BuildContext context, Chat chat, ThemeData th
         ),
         preferredSize: const Size.fromHeight(0.5),
       ),
-      leading: buildBackButton(context, skin: skin),
+      leading: const BackButton(),
       backgroundColor: backgroundColor,
       actionsIconTheme: IconThemeData(color: theme.primaryColor),
       iconTheme: IconThemeData(color: theme.primaryColor),
@@ -827,7 +827,7 @@ Widget buildConversationViewHeader(BuildContext context, Chat chat, ThemeData th
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              buildBackButton(context, skin: skin),
+              const BackButton(),
               if (ChatBloc().unreads.value > 0)
                 Container(
                   width: 25.0,

--- a/lib/helpers/ui/ui_helpers.dart
+++ b/lib/helpers/ui/ui_helpers.dart
@@ -7,9 +7,9 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide BackButton;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide BackButton;
 import 'package:flutter/services.dart';
 import 'package:gesture_x_detector/gesture_x_detector.dart';
 import 'package:get/get.dart';
@@ -60,48 +60,6 @@ class BackButton extends StatelessWidget {
       ),
     );
   }
-}
-
-// todo remove
-Widget buildBackButton(BuildContext context, {EdgeInsets padding = EdgeInsets.zero, double? iconSize, Skins? skin, bool Function()? callback}) {
-  return Material(
-    color: Colors.transparent,
-    child: Container(
-      padding: padding,
-      width: 48,
-      child: XGestureDetector(
-        supportTouch: true,
-        onTap: !kIsDesktop ? null : (details) {
-          final result = callback?.call() ?? true;
-          if (result) {
-            if (Get.isSnackbarOpen) {
-              Get.closeAllSnackbars();
-            }
-            Navigator.of(context).pop();
-          }
-        },
-        child: IconButton(
-          iconSize: iconSize ?? (ss.settings.skin.value != Skins.Material ? 30 : 24),
-          icon: skin != null
-              ? Icon(skin != Skins.Material ? CupertinoIcons.back : Icons.arrow_back, color: context.theme.colorScheme.primary)
-              : Obx(() => Icon(ss.settings.skin.value != Skins.Material ? CupertinoIcons.back : Icons.arrow_back,
-                  color: context.theme.colorScheme.primary)),
-          onPressed: () {
-            if (kIsDesktop) return;
-            final result = callback?.call() ?? true;
-            if (result) {
-              if (Get.isSnackbarOpen) {
-                Get.closeAllSnackbars();
-              }
-              Navigator.of(context).pop();
-            }
-          },
-        ),
-      ),
-    ),
-  );
-}
-
 Widget buildProgressIndicator(BuildContext context, {double size = 20, double strokeWidth = 2}) {
   return ss.settings.skin.value == Skins.iOS
       ? Theme(


### PR DESCRIPTION
## Summary
- drop deprecated `buildBackButton` helper
- switch call sites to shared `BackButton` widget
- hide Flutter's built-in `BackButton` to avoid name clashes

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae3dc75644833180a7fb544a738fd4