### PR TITLE
feat: index message queries by chat and date

### DIFF
--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -43,9 +43,13 @@ class GetChatAttachments extends AsyncTask<List<dynamic>, List<Attachment>> {
       /// Query the [Database.messageBox] for all the message IDs and order by date
       /// descending
       final query = (Database.messages.query(includeDeleted
-          ? Message_.dateCreated.notNull().and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
-          : Message_.dateDeleted.isNull().and(Message_.dateCreated.notNull()))
-            ..link(Message_.chat, Chat_.id.equals(chatId))
+          ? Message_.dateCreated
+              .notNull()
+              .and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
+          : Message_.dateDeleted
+              .isNull()
+              .and(Message_.dateCreated.notNull()))
+            .and(Message_.chatId.equals(chatId))
             ..order(Message_.dateCreated, flags: Order.descending))
           .build();
       final messages = query.find();
@@ -98,10 +102,14 @@ class GetMessages extends AsyncTask<List<dynamic>, List<Message>> {
       final messages = <Message>[];
       if (searchAround == null) {
         final query = (Database.messages.query(includeDeleted
-            ? Message_.dateCreated.notNull().and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
-            : Message_.dateDeleted.isNull().and(Message_.dateCreated.notNull()))
-          ..link(Message_.chat, Chat_.id.equals(chatId))
-          ..order(Message_.dateCreated, flags: Order.descending))
+                ? Message_.dateCreated
+                    .notNull()
+                    .and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
+                : Message_.dateDeleted
+                    .isNull()
+                    .and(Message_.dateCreated.notNull()))
+              .and(Message_.chatId.equals(chatId))
+            ..order(Message_.dateCreated, flags: Order.descending))
             .build();
         query
           ..limit = limit
@@ -109,20 +117,34 @@ class GetMessages extends AsyncTask<List<dynamic>, List<Message>> {
         messages.addAll(query.find());
         query.close();
       } else {
-        final beforeQuery = (Database.messages.query(Message_.dateCreated.lessThan(searchAround).and(includeDeleted
-            ? Message_.dateCreated.notNull().and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
-            : Message_.dateDeleted.isNull().and(Message_.dateCreated.notNull())))
-          ..link(Message_.chat, Chat_.id.equals(chatId))
-          ..order(Message_.dateCreated, flags: Order.descending))
+        final beforeQuery = (Database.messages.query(
+                Message_.dateCreated
+                    .lessThan(searchAround)
+                    .and(includeDeleted
+                        ? Message_.dateCreated
+                            .notNull()
+                            .and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
+                        : Message_.dateDeleted
+                            .isNull()
+                            .and(Message_.dateCreated.notNull()))
+                    .and(Message_.chatId.equals(chatId)))
+              ..order(Message_.dateCreated, flags: Order.descending))
             .build();
         beforeQuery.limit = limit;
         final before = beforeQuery.find();
         beforeQuery.close();
-        final afterQuery = (Database.messages.query(Message_.dateCreated.greaterThan(searchAround).and(includeDeleted
-            ? Message_.dateCreated.notNull().and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
-            : Message_.dateDeleted.isNull().and(Message_.dateCreated.notNull())))
-          ..link(Message_.chat, Chat_.id.equals(chatId))
-          ..order(Message_.dateCreated))
+        final afterQuery = (Database.messages.query(
+                Message_.dateCreated
+                    .greaterThan(searchAround)
+                    .and(includeDeleted
+                        ? Message_.dateCreated
+                            .notNull()
+                            .and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
+                        : Message_.dateDeleted
+                            .isNull()
+                            .and(Message_.dateCreated.notNull()))
+                    .and(Message_.chatId.equals(chatId)))
+              ..order(Message_.dateCreated))
             .build();
         afterQuery.limit = limit;
         final after = afterQuery.find();
@@ -783,9 +805,13 @@ class Chat {
     if (kIsWeb || chat.id == null) return [];
     return Database.runInTransaction(TxMode.read, () {
       final query = (Database.messages.query(includeDeleted
-              ? Message_.dateCreated.notNull().and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
-              : Message_.dateDeleted.isNull().and(Message_.dateCreated.notNull()))
-            ..link(Message_.chat, Chat_.id.equals(chat.id!))
+              ? Message_.dateCreated
+                  .notNull()
+                  .and(Message_.dateDeleted.isNull().or(Message_.dateDeleted.notNull()))
+              : Message_.dateDeleted
+                  .isNull()
+                  .and(Message_.dateCreated.notNull()))
+            .and(Message_.chatId.equals(chat.id!))
             ..order(Message_.dateCreated, flags: Order.descending))
           .build();
       query

--- a/lib/objectbox-model.json
+++ b/lib/objectbox-model.json
@@ -598,7 +598,18 @@
           "type": 1
         }
       ],
-      "relations": []
+      "relations": [],
+      "indexes": [
+        {
+          "id": "17:7910730320894018600",
+          "name": "chatId_dateCreated",
+          "unique": false,
+          "properties": [
+            "39:1372898255926257108",
+            "9:5531207057664871058"
+          ]
+        }
+      ]
     },
     {
       "id": "15:7753273527865539946",
@@ -730,7 +741,7 @@
     }
   ],
   "lastEntityId": "17:2547083341603323785",
-  "lastIndexId": "16:6243763364531768800",
+  "lastIndexId": "17:7910730320894018600",
   "lastRelationId": "1:7492985733214117623",
   "lastSequenceId": "0:0",
   "modelVersion": 5,


### PR DESCRIPTION
## Summary
- add compound index on Message.chatId and dateCreated
- query messages by chatId directly instead of link to Chat

## Testing
- `flutter pub run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae43cc0d1083319f9f56b1780b8c61