### PR TITLE
feat: add message search filters

### DIFF
--- a/lib/app/layouts/chat_selector_view/chat_selector_view.dart
+++ b/lib/app/layouts/chat_selector_view/chat_selector_view.dart
@@ -6,6 +6,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/app/layouts/chat_selector_view/search_panel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -34,6 +35,9 @@ class ChatSelectorViewState extends OptimizedState<ChatSelectorView> {
   List<Chat> filteredChats = [];
   String? oldSearch;
   Timer? _debounce;
+  String? senderFilter;
+  DateTimeRange? dateRangeFilter;
+  String? attachmentFilter;
 
   @override
   void initState() {
@@ -132,6 +136,12 @@ class ChatSelectorViewState extends OptimizedState<ChatSelectorView> {
                       ),
                       filled: false),
                 ),
+              ),
+              const SizedBox(height: 10),
+              ChatSearchPanel(
+                onSenderChanged: (s) => senderFilter = s,
+                onDateRangeChanged: (r) => dateRangeFilter = r,
+                onAttachmentChanged: (t) => attachmentFilter = t,
               ),
               Expanded(
                 child: Obx(() {

--- a/lib/app/layouts/chat_selector_view/search_panel.dart
+++ b/lib/app/layouts/chat_selector_view/search_panel.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class ChatSearchPanel extends StatefulWidget {
+  const ChatSearchPanel({
+    super.key,
+    this.onSenderChanged,
+    this.onDateRangeChanged,
+    this.onAttachmentChanged,
+  });
+
+  final ValueChanged<String>? onSenderChanged;
+  final ValueChanged<DateTimeRange?>? onDateRangeChanged;
+  final ValueChanged<String?>? onAttachmentChanged;
+
+  @override
+  ChatSearchPanelState createState() => ChatSearchPanelState();
+}
+
+class ChatSearchPanelState extends State<ChatSearchPanel> {
+  final TextEditingController senderController = TextEditingController();
+  DateTimeRange? range;
+  String? attachmentType;
+
+  Future<void> pickDateRange() async {
+    final picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now(),
+      initialDateRange: range,
+    );
+    setState(() => range = picked);
+    if (widget.onDateRangeChanged != null) {
+      widget.onDateRangeChanged!(picked);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(
+          controller: senderController,
+          decoration: const InputDecoration(
+            labelText: 'Sender',
+            prefixIcon: Icon(Icons.person),
+          ),
+          onChanged: widget.onSenderChanged,
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: Text(range == null
+                  ? 'No date range selected'
+                  : '${range!.start.toLocal()} - ${range!.end.toLocal()}'),
+            ),
+            TextButton(
+              onPressed: pickDateRange,
+              child: const Text('Select Dates'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        DropdownButton<String>(
+          value: attachmentType,
+          hint: const Text('Attachment Type'),
+          items: const [
+            DropdownMenuItem(value: 'image', child: Text('Images')),
+            DropdownMenuItem(value: 'video', child: Text('Videos')),
+            DropdownMenuItem(value: 'file', child: Text('Files')),
+          ],
+          onChanged: (val) {
+            setState(() => attachmentType = val);
+            if (widget.onAttachmentChanged != null) {
+              widget.onAttachmentChanged!(val);
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/objectbox-model.json
+++ b/lib/objectbox-model.json
@@ -89,7 +89,7 @@
     },
     {
       "id": "3:9017250848141753702",
-      "lastPropertyId": "28:3841196368520260614",
+      "lastPropertyId": "29:1470241693312285363",
       "name": "Chat",
       "properties": [
         {
@@ -204,6 +204,13 @@
           "id": "28:3841196368520260614",
           "name": "lastReadMessageGuid",
           "type": 9
+        },
+        {
+          "id": "29:1470241693312285363",
+          "name": "fullText",
+          "type": 9,
+          "flags": 2080,
+          "indexId": "17:8525126353005467357"
         }
       ],
       "relations": [
@@ -381,7 +388,7 @@
     },
     {
       "id": "13:4148278195232901830",
-      "lastPropertyId": "51:6421366235089828344",
+      "lastPropertyId": "52:1840671467277910017",
       "name": "Message",
       "properties": [
         {
@@ -596,6 +603,13 @@
           "id": "51:6421366235089828344",
           "name": "isPinned",
           "type": 1
+        },
+        {
+          "id": "52:1840671467277910017",
+          "name": "fullText",
+          "type": 9,
+          "flags": 2080,
+          "indexId": "18:5074771669273068157"
         }
       ],
       "relations": []
@@ -730,7 +744,7 @@
     }
   ],
   "lastEntityId": "17:2547083341603323785",
-  "lastIndexId": "16:6243763364531768800",
+  "lastIndexId": "18:5074771669273068157",
   "lastRelationId": "1:7492985733214117623",
   "lastSequenceId": "0:0",
   "modelVersion": 5,

--- a/lib/services/ui/search/search_service.dart
+++ b/lib/services/ui/search/search_service.dart
@@ -1,0 +1,36 @@
+import 'package:bluebubbles/database/database.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:get/get.dart';
+
+SearchService ss = Get.isRegistered<SearchService>() ? Get.find<SearchService>() : Get.put(SearchService());
+
+class SearchService extends GetxService {
+  Future<List<Message>> search({
+    String? sender,
+    DateTime? start,
+    DateTime? end,
+    String? attachmentType,
+  }) async {
+    List<Message> messages = Database.messages.getAll();
+
+    return messages.where((m) {
+      if (sender != null && sender.isNotEmpty) {
+        final address = m.handle?.address ?? m.handle?.originalAddress;
+        if (address == null || !address.contains(sender)) {
+          return false;
+        }
+      }
+      if (start != null && (m.dateCreated == null || m.dateCreated!.isBefore(start))) {
+        return false;
+      }
+      if (end != null && (m.dateCreated == null || m.dateCreated!.isAfter(end))) {
+        return false;
+      }
+      if (attachmentType != null && attachmentType.isNotEmpty) {
+        final hasType = m.dbAttachments.any((a) => a.mimeType?.contains(attachmentType) ?? false);
+        if (!hasType) return false;
+      }
+      return true;
+    }).toList();
+  }
+}


### PR DESCRIPTION
## Summary
- add full-text indexed fields to Chat and Message in objectbox model
- introduce search service with sender, date range and attachment filters
- surface new search filters in chat selector panel

## Testing
- `dart format lib/services/ui/search/search_service.dart lib/app/layouts/chat_selector_view/search_panel.dart lib/app/layouts/chat_selector_view/chat_selector_view.dart` (failed: command not found)
- `sudo apt-get update` (failed: repository not signed)
- `flutter test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae43cc43248331a7275d2bd5a670f5