### PR TITLE
Add accessibility settings and semantic enhancements

### DIFF
--- a/lib/app/components/circle_progress_bar.dart
+++ b/lib/app/components/circle_progress_bar.dart
@@ -112,25 +112,29 @@ class CircleProgressBarState extends OptimizedState<CircleProgressBar> with Sing
 
   @override
   Widget build(BuildContext context) {
-    return AspectRatio(
-      aspectRatio: 1,
-      child: AnimatedBuilder(
-        animation: curve,
-        child: Container(),
-        builder: (context, child) {
-          final backgroundColor = backgroundColorTween?.evaluate(curve) ?? widget.backgroundColor;
-          final foregroundColor = foregroundColorTween?.evaluate(curve) ?? widget.foregroundColor;
+    return Semantics(
+      label: 'Progress ${(widget.value * 100).round()}%',
+      value: '${(widget.value * 100).round()}%',
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: AnimatedBuilder(
+          animation: curve,
+          child: Container(),
+          builder: (context, child) {
+            final backgroundColor = backgroundColorTween?.evaluate(curve) ?? widget.backgroundColor;
+            final foregroundColor = foregroundColorTween?.evaluate(curve) ?? widget.foregroundColor;
 
-          return CustomPaint(
-            child: child,
-            foregroundPainter: CircleProgressBarPainter(
-              strokeWidth: 4,
-              backgroundColor: backgroundColor,
-              foregroundColor: foregroundColor,
-              percentage: valueTween!.evaluate(curve),
-            ),
-          );
-        },
+            return CustomPaint(
+              child: child,
+              foregroundPainter: CircleProgressBarPainter(
+                strokeWidth: 4,
+                backgroundColor: backgroundColor,
+                foregroundColor: foregroundColor,
+                percentage: valueTween!.evaluate(curve),
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/app/layouts/conversation_view/widgets/text_field/send_button.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/send_button.dart
@@ -41,29 +41,34 @@ class SendButtonState extends OptimizedState<SendButton> with SingleTickerProvid
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onSecondaryTap: () {
-        if (controller.isAnimating) {
-          controller.reset();
-        } else {
-          widget.onLongPress.call();
-        }
-      },
-      child: TextButton(
-        style: TextButton.styleFrom(
-          backgroundColor: iOS ? context.theme.colorScheme.primary : null,
-          shape: const CircleBorder(),
-          padding: const EdgeInsets.all(0),
-          maximumSize: const Size(32, 32),
-          minimumSize: const Size(32, 32),
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        ),
-        child: AnimatedBuilder(
-          animation: controller,
-          builder: (context, widget) {
-            return Container(
-              constraints: const BoxConstraints(minHeight: 32, minWidth: 32),
-              decoration: BoxDecoration(
+      return GestureDetector(
+        onSecondaryTap: () {
+          if (controller.isAnimating) {
+            controller.reset();
+          } else {
+            widget.onLongPress.call();
+          }
+        },
+        child: FocusTraversalOrder(
+          order: const NumericFocusOrder(3.0),
+          child: Semantics(
+            label: 'Send message',
+            button: true,
+            child: TextButton(
+              style: TextButton.styleFrom(
+                backgroundColor: iOS ? context.theme.colorScheme.primary : null,
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(0),
+                maximumSize: const Size(32, 32),
+                minimumSize: const Size(32, 32),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: AnimatedBuilder(
+                animation: controller,
+                builder: (context, widget) {
+                  return Container(
+                    constraints: const BoxConstraints(minHeight: 32, minWidth: 32),
+                    decoration: BoxDecoration(
                   shape: iOS ? BoxShape.circle : BoxShape.rectangle,
                   borderRadius: iOS ? null : BorderRadius.circular(10),
                   gradient: iOS || controller.value != 0
@@ -90,26 +95,28 @@ class SendButtonState extends OptimizedState<SendButton> with SingleTickerProvid
                 size: iOS || controller.value != 0 ? 20 : 28,
               ),
             );
-          },
+                },
+              ),
+              onPressed: () {
+                if (controller.isAnimating) {
+                  controller.reset();
+                } else if (ss.settings.sendDelay.value != 0) {
+                  controller.forward();
+                } else {
+                  HapticFeedback.lightImpact();
+                  widget.sendMessage.call();
+                }
+              },
+              onLongPress: () {
+                if (controller.isAnimating) {
+                  controller.reset();
+                } else {
+                  widget.onLongPress.call();
+                }
+              },
+            ),
+          ),
         ),
-        onPressed: () {
-          if (controller.isAnimating) {
-            controller.reset();
-          } else if (ss.settings.sendDelay.value != 0) {
-            controller.forward();
-          } else {
-            HapticFeedback.lightImpact();
-            widget.sendMessage.call();
-          }
-        },
-        onLongPress: () {
-          if (controller.isAnimating) {
-            controller.reset();
-          } else {
-            widget.onLongPress.call();
-          }
-        },
-      ),
-    );
+      );
   }
 }

--- a/lib/app/layouts/settings/accessibility/accessibility_panel.dart
+++ b/lib/app/layouts/settings/accessibility/accessibility_panel.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/services/services.dart';
+
+class AccessibilityPanel extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _AccessibilityPanelState();
+}
+
+class _AccessibilityPanelState extends OptimizedState<AccessibilityPanel> {
+  void saveSettings() {
+    ss.saveSettings(ss.settings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: 'Accessibility',
+      iosSubtitle: iosSubtitle,
+      materialSubtitle: materialSubtitle,
+      tileColor: tileColor,
+      headerColor: headerColor,
+      bodySlivers: [
+        SliverList(
+          delegate: SliverChildListDelegate([
+            SettingsSection(
+              backgroundColor: tileColor,
+              children: [
+                Container(
+                  padding: const EdgeInsets.only(left: 15, top: 10),
+                  child: Text('Text Scale', style: context.theme.textTheme.bodyLarge),
+                ),
+                Obx(() => SettingsSlider(
+                      startingVal: ss.settings.textScale.value,
+                      update: (double val) => ss.settings.textScale.value = val,
+                      onChangeEnd: (double val) => saveSettings(),
+                      min: 1.0,
+                      max: 2.0,
+                      divisions: 10,
+                      backgroundColor: tileColor,
+                      leading: const SettingsLeadingIcon(
+                        iosIcon: CupertinoIcons.textformat_size,
+                        materialIcon: Icons.format_size,
+                        containerColor: Colors.indigo,
+                      ),
+                    )),
+                const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                Obx(() => SettingsSwitch(
+                      onChanged: (bool val) {
+                        ss.settings.highContrast.value = val;
+                        saveSettings();
+                      },
+                      initialVal: ss.settings.highContrast.value,
+                      title: 'High Contrast',
+                      backgroundColor: tileColor,
+                      leading: const SettingsLeadingIcon(
+                        iosIcon: CupertinoIcons.circle_lefthalf_fill,
+                        materialIcon: Icons.brightness_6,
+                        containerColor: Colors.black,
+                      ),
+                    )),
+              ],
+            ),
+          ]),
+        )
+      ],
+    );
+  }
+}
+

--- a/lib/app/layouts/settings/settings_page.dart
+++ b/lib/app/layouts/settings/settings_page.dart
@@ -19,6 +19,7 @@ import 'package:bluebubbles/app/layouts/settings/pages/advanced/private_api_pane
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/redacted_mode_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/server_management_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/scheduling/scheduled_messages_panel.dart';
+import 'package:bluebubbles/app/layouts/settings/accessibility/accessibility_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/theming/theming_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/misc/troubleshoot_panel.dart';
@@ -341,6 +342,31 @@ class _SettingsPageState extends OptimizedState<SettingsPage> {
                                         iosIcon: CupertinoIcons.paintbrush_fill,
                                         materialIcon: Icons.palette,
                                         containerColor: Colors.blueGrey),
+                                  ),
+                                ],
+                              ),
+                              SettingsHeader(
+                                  iosSubtitle: iosSubtitle,
+                                  materialSubtitle: materialSubtitle,
+                                  text: "Accessibility"),
+                              SettingsSection(
+                                backgroundColor: tileColor,
+                                children: [
+                                  SettingsTile(
+                                    backgroundColor: tileColor,
+                                    title: "Accessibility Settings",
+                                    onTap: () {
+                                      ns.pushAndRemoveSettingsUntil(
+                                        context,
+                                        AccessibilityPanel(),
+                                        (route) => route.isFirst,
+                                      );
+                                    },
+                                    trailing: const NextButton(),
+                                    leading: const SettingsLeadingIcon(
+                                        iosIcon: CupertinoIcons.eye,
+                                        materialIcon: Icons.accessibility_new,
+                                        containerColor: Colors.purple),
                                   ),
                                 ],
                               ),

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -40,6 +40,8 @@ class Settings {
   final RxBool colorfulBubbles = false.obs;
   final RxBool hideDividers = false.obs;
   final RxDouble scrollVelocity = 1.00.obs;
+  final RxDouble textScale = 1.0.obs;
+  final RxBool highContrast = false.obs;
   final RxBool sendWithReturn = false.obs;
   final RxBool doubleTapForDetails = false.obs;
   final RxBool denseChatTiles = false.obs;
@@ -309,6 +311,8 @@ class Settings {
       'colorfulBubbles': colorfulBubbles.value,
       'hideDividers': hideDividers.value,
       'scrollVelocity': scrollVelocity.value,
+      'textScale': textScale.value,
+      'highContrast': highContrast.value,
       'sendWithReturn': sendWithReturn.value,
       'doubleTapForDetails': doubleTapForDetails.value,
       'denseChatTiles': denseChatTiles.value,
@@ -449,6 +453,8 @@ class Settings {
     ss.settings.colorfulBubbles.value = map['colorfulBubbles'] ?? false;
     ss.settings.hideDividers.value = map['hideDividers'] ?? false;
     ss.settings.scrollVelocity.value = map['scrollVelocity']?.toDouble() ?? 1;
+    ss.settings.textScale.value = map['textScale']?.toDouble() ?? 1.0;
+    ss.settings.highContrast.value = map['highContrast'] ?? false;
     ss.settings.sendWithReturn.value = map['sendWithReturn'] ?? false;
     ss.settings.doubleTapForDetails.value = map['doubleTapForDetails'] ?? false;
     ss.settings.denseChatTiles.value = map['denseChatTiles'] ?? false;
@@ -595,6 +601,8 @@ class Settings {
     s.colorfulBubbles.value = map['colorfulBubbles'] ?? false;
     s.hideDividers.value = map['hideDividers'] ?? false;
     s.scrollVelocity.value = map['scrollVelocity']?.toDouble() ?? 1;
+    s.textScale.value = map['textScale']?.toDouble() ?? 1.0;
+    s.highContrast.value = map['highContrast'] ?? false;
     s.sendWithReturn.value = map['sendWithReturn'] ?? false;
     s.doubleTapForDetails.value = map['doubleTapForDetails'] ?? false;
     s.denseChatTiles.value = map['denseChatTiles'] ?? false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,12 +112,19 @@ class Main extends StatelessWidget {
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyI): const OpenChatDetailsIntent(),
           LogicalKeySet(LogicalKeyboardKey.escape): const GoBackIntent(),
         },
-        builder: (context, child) => SafeArea(
-          top: false,
-          bottom: false,
-          child: SecureApplication(
-            child: Builder(
-              builder: (context) {
+        builder: (context, child) => Obx(() {
+          final media = MediaQuery.of(context);
+          return SafeArea(
+            top: false,
+            bottom: false,
+            child: MediaQuery(
+              data: media.copyWith(
+                textScaler: TextScaler.linear(ss.settings.textScale.value),
+                highContrast: ss.settings.highContrast.value,
+              ),
+              child: SecureApplication(
+                child: Builder(
+                  builder: (context) {
                 if (ss.canAuthenticate && (!ls.isAlive || !StartupTasks.uiReady.isCompleted)) {
                   if (ss.settings.shouldSecure.value) {
                     SecureApplicationProvider.of(context, listen: false)!.lock();
@@ -204,6 +211,8 @@ class Main extends StatelessWidget {
             ),
           ),
         ),
+      );
+    }),
         defaultTransition: Transition.cupertino,
       ),
     );

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -24,6 +24,7 @@ import 'package:timezone/timezone.dart';
 import 'package:universal_html/html.dart' hide File, Platform, Navigator;
 import 'package:universal_io/io.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:flutter/semantics.dart';
 
 NotificationsService notif = Get.isRegistered<NotificationsService>() ? Get.find<NotificationsService>() : Get.put(NotificationsService());
 
@@ -186,8 +187,9 @@ class NotificationsService extends GetxService {
     final guid = chat.guid;
     final contactName = message.handle?.displayName ?? "Unknown";
     final title = isGroup ? chat.getTitle() : contactName;
-    final text = hideContent ? "iMessage" : MessageHelper.getNotificationText(message);
-    final isReaction = !isNullOrEmpty(message.associatedMessageGuid);
+      final text = hideContent ? "iMessage" : MessageHelper.getNotificationText(message);
+      final isReaction = !isNullOrEmpty(message.associatedMessageGuid);
+      SemanticsService.announce('$title: $text', TextDirection.ltr);
     final personIcon = (await rootBundle.load("assets/images/person64.png")).buffer.asUint8List();
 
     Uint8List chatIcon = await avatarAsBytes(chat: chat, quality: 256);

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -1,0 +1,49 @@
+import 'package:bluebubbles/app/components/circle_progress_bar.dart';
+import 'package:bluebubbles/app/layouts/conversation_view/widgets/text_field/send_button.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    setupServices();
+    await ss.init(headless: true);
+  });
+
+  testWidgets('SendButton has semantics and focus order', (tester) async {
+    final handle = tester.ensureSemantics();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SendButton(
+          onLongPress: () {},
+          sendMessage: () {},
+        ),
+      ),
+    ));
+    final semantics = tester.getSemantics(find.byType(SendButton));
+    expect(semantics.label, 'Send message');
+    expect(semantics.hasFlag(SemanticsFlag.isButton), isTrue);
+    expect((semantics.sortKey as OrdinalSortKey).order, 3.0);
+    handle.dispose();
+  });
+
+  testWidgets('CircleProgressBar reports progress semantics', (tester) async {
+    final handle = tester.ensureSemantics();
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: CircleProgressBar(
+        backgroundColor: Color(0x00000000),
+        foregroundColor: Color(0xFF0000FF),
+        value: 0.5,
+      ),
+    ));
+    final semantics = tester.getSemantics(find.byType(CircleProgressBar));
+    expect(semantics.label, 'Progress 50%');
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add accessibility panel with text scale and high contrast settings
- ensure conversation send button and progress bar expose semantics and focus order
- announce new messages for screen readers and apply user text scaling/high contrast across app
- add widget tests covering accessibility semantics

## Testing
- `flutter test test/accessibility_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4799505c8331a7e71b4feb624ee0